### PR TITLE
Add perimeter status CSV and source tracking

### DIFF
--- a/city_analysis/perimeter_status.py
+++ b/city_analysis/perimeter_status.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import List
+
+from .geometry import default_alps_polygon_with_source
+from .io_utils import write_csv
+
+
+def main() -> None:
+    """Generate a CSV describing the Alps perimeter source and any warnings/errors."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    )
+
+    log_records: List[logging.LogRecord] = []
+
+    class Collector(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:  # type: ignore[override]
+            if record.levelno >= logging.WARNING:
+                log_records.append(record)
+
+    logging.getLogger().addHandler(Collector())
+
+    _, source = default_alps_polygon_with_source()
+
+    errors = [r.getMessage() for r in log_records if r.levelno >= logging.ERROR]
+    warnings = [r.getMessage() for r in log_records if r.levelno == logging.WARNING]
+
+    out_dir = Path("outputs")
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    write_csv(out_dir / "perimeter_status.csv", [{
+        "perimeter_source": source,
+        "errors": "|".join(errors),
+        "warnings": "|".join(warnings),
+    }])
+
+
+if __name__ == "__main__":
+    main()

--- a/outputs/perimeter_status.csv
+++ b/outputs/perimeter_status.csv
@@ -1,0 +1,2 @@
+errors,perimeter_source,warnings
+,data_source,


### PR DESCRIPTION
## Summary
- Add `default_alps_polygon_with_source` to identify whether the Alps perimeter comes from a GeoJSON file or fallback bounds
- Create `perimeter_status` script that captures warnings/errors and writes a perimeter status CSV
- Include generated `perimeter_status.csv` demonstrating the current perimeter source

## Testing
- `python -m city_analysis.perimeter_status`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a70d6a7560832d9fff065fcd2a8687