### PR TITLE
Add map with country colors and population-sized markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Outputs in `outputs/`:
 - `alps_cities.csv` - CSV with columns: name, country, latitude, longitude, population, elevation, elevation_source, elevation_confidence, source, distance_km_to_alps
 - `alps_cities.geojson` - GeoJSON with all place data including elevation and distance metrics
 - `alps_cities_map.html` - Interactive map of all places (Folium)
+- `alps_cities_country_pop_map.html` - Map with cities color-coded by country and circle size scaled by population
 
 ## Notes
 - Licensing: GeoNames (CC BY 4.0), OSM (ODbL). Validate terms before redistribution.

--- a/city_analysis/cli.py
+++ b/city_analysis/cli.py
@@ -14,7 +14,12 @@ from .geometry import default_alps_polygon, load_perimeter, polygon_bounds
 from .geonames import fetch_geonames_cities
 from .overpass import fetch_overpass_bbox_tiled
 from .normalize import filter_within_perimeter, dedupe_places, enforce_min_population
-from .io_utils import write_csv, write_geojson, write_html_map
+from .io_utils import (
+    write_csv,
+    write_geojson,
+    write_html_map,
+    write_html_map_by_country_and_population,
+)
 from .analysis import top_n_by_population, summarize
 from .country_filters import filter_excluded_countries, fill_missing_country
 from .distance import add_distance_to_perimeter_km
@@ -117,6 +122,9 @@ def main() -> None:
     write_csv(out_dir / "alps_cities.csv", enriched)
     write_geojson(out_dir / "alps_cities.geojson", enriched)
     write_html_map(out_dir / "alps_cities_map.html", enriched)
+    write_html_map_by_country_and_population(
+        out_dir / "alps_cities_country_pop_map.html", enriched
+    )
 
     # Console summary
     stats = summarize(enriched)

--- a/outputs/alps_cities_country_pop_map.html
+++ b/outputs/alps_cities_country_pop_map.html
@@ -1,0 +1,9209 @@
+<!DOCTYPE html>
+<html>
+<head>
+    
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.js"></script>
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.9.3/dist/leaflet.css"/>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css"/>
+    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap-glyphicons.css"/>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.2.0/css/all.min.css"/>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css"/>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/python-visualization/folium/folium/templates/leaflet.awesome.rotate.min.css"/>
+    
+            <meta name="viewport" content="width=device-width,
+                initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+            <style>
+                #map_e2ec93003f78b87f72b552ab4b1bae4c {
+                    position: relative;
+                    width: 100.0%;
+                    height: 100.0%;
+                    left: 0.0%;
+                    top: 0.0%;
+                }
+                .leaflet-container { font-size: 1rem; }
+            </style>
+
+            <style>html, body {
+                width: 100%;
+                height: 100%;
+                margin: 0;
+                padding: 0;
+            }
+            </style>
+
+            <style>#map {
+                position:absolute;
+                top:0;
+                bottom:0;
+                right:0;
+                left:0;
+                }
+            </style>
+
+            <script>
+                L_NO_TOUCH = false;
+                L_DISABLE_3D = false;
+            </script>
+
+        
+</head>
+<body>
+    
+    
+            <div class="folium-map" id="map_e2ec93003f78b87f72b552ab4b1bae4c" ></div>
+        
+</body>
+<script>
+    
+    
+            var map_e2ec93003f78b87f72b552ab4b1bae4c = L.map(
+                "map_e2ec93003f78b87f72b552ab4b1bae4c",
+                {
+                    center: [46.13357305530303, 11.879065749747474],
+                    crs: L.CRS.EPSG3857,
+                    ...{
+  "zoom": 6,
+  "zoomControl": true,
+  "preferCanvas": false,
+}
+
+                }
+            );
+
+            
+
+        
+    
+            var tile_layer_8ebded58499f9ab19bc44e24111dea20 = L.tileLayer(
+                "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
+                {
+  "minZoom": 0,
+  "maxZoom": 19,
+  "maxNativeZoom": 19,
+  "noWrap": false,
+  "attribution": "\u0026copy; \u003ca href=\"https://www.openstreetmap.org/copyright\"\u003eOpenStreetMap\u003c/a\u003e contributors",
+  "subdomains": "abc",
+  "detectRetina": false,
+  "tms": false,
+  "opacity": 1,
+}
+
+            );
+        
+    
+            tile_layer_8ebded58499f9ab19bc44e24111dea20.addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+            var circle_marker_980296fa65848c9d0e44b1d1f195984a = L.circleMarker(
+                [45.64953, 13.77678],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 20.0, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_9ad38655aab7b20b53014a21332746ab = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_6f9710f91a1c64c4416e191694412925 = $(`<div id="html_6f9710f91a1c64c4416e191694412925" style="width: 100.0%; height: 100.0%;">Trieste (IT) — pop 204,338</div>`)[0];
+                popup_9ad38655aab7b20b53014a21332746ab.setContent(html_6f9710f91a1c64c4416e191694412925);
+            
+        
+
+        circle_marker_980296fa65848c9d0e44b1d1f195984a.bindPopup(popup_9ad38655aab7b20b53014a21332746ab)
+        ;
+
+        
+    
+    
+            var circle_marker_7d1808677c943db55ceaa9266ec8c629 = L.circleMarker(
+                [45.49167, 12.24538],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 15.734541513637184, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_fe1b89d3a8e74b1cfada863dddb3cb8b = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_25b44c2bdf2631b55cb7f137b66c7f61 = $(`<div id="html_25b44c2bdf2631b55cb7f137b66c7f61" style="width: 100.0%; height: 100.0%;">Mestre (IT) — pop 147,662</div>`)[0];
+                popup_fe1b89d3a8e74b1cfada863dddb3cb8b.setContent(html_25b44c2bdf2631b55cb7f137b66c7f61);
+            
+        
+
+        circle_marker_7d1808677c943db55ceaa9266ec8c629.bindPopup(popup_fe1b89d3a8e74b1cfada863dddb3cb8b)
+        ;
+
+        
+    
+    
+            var circle_marker_b652bad520e31ef554698c5f23c08c9f = L.circleMarker(
+                [47.26266, 11.39454],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 14.592916491059064, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_8ae379bb10e5d2bbfc4bb9b20cfce1ca = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_70021686082b6f9fa1fc19a9ed78ffab = $(`<div id="html_70021686082b6f9fa1fc19a9ed78ffab" style="width: 100.0%; height: 100.0%;">Innsbruck (AT) — pop 132,493</div>`)[0];
+                popup_8ae379bb10e5d2bbfc4bb9b20cfce1ca.setContent(html_70021686082b6f9fa1fc19a9ed78ffab);
+            
+        
+
+        circle_marker_b652bad520e31ef554698c5f23c08c9f.bindPopup(popup_8ae379bb10e5d2bbfc4bb9b20cfce1ca)
+        ;
+
+        
+    
+    
+            var circle_marker_8dabd5bc1dac4abe7bcabd4232929361 = L.circleMarker(
+                [46.06787, 11.12108],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 13.706047925823349, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_5461ccf7c52b4e00964b595c6894f9a9 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_35aeed0298b0a18ba8d2dede22d3c0e8 = $(`<div id="html_35aeed0298b0a18ba8d2dede22d3c0e8" style="width: 100.0%; height: 100.0%;">Trento (IT) — pop 120,709</div>`)[0];
+                popup_5461ccf7c52b4e00964b595c6894f9a9.setContent(html_35aeed0298b0a18ba8d2dede22d3c0e8);
+            
+        
+
+        circle_marker_8dabd5bc1dac4abe7bcabd4232929361.bindPopup(popup_5461ccf7c52b4e00964b595c6894f9a9)
+        ;
+
+        
+    
+    
+            var circle_marker_b693a09af9c2aa017cd0f44537895a39 = L.circleMarker(
+                [45.5488306, 11.5478825],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 13.122328255764947, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_dd0f801c39cbeaf13813bae56842196d = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_7bda901287e75ea4feae5beccaa14628 = $(`<div id="html_7bda901287e75ea4feae5beccaa14628" style="width: 100.0%; height: 100.0%;">Vicenza (IT) — pop 112,953</div>`)[0];
+                popup_dd0f801c39cbeaf13813bae56842196d.setContent(html_7bda901287e75ea4feae5beccaa14628);
+            
+        
+
+        circle_marker_b693a09af9c2aa017cd0f44537895a39.bindPopup(popup_dd0f801c39cbeaf13813bae56842196d)
+        ;
+
+        
+    
+    
+            var circle_marker_ea86ab369d9008418d794ea4b9a82aec = L.circleMarker(
+                [46.49067, 11.33982],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 12.70711662351737, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_439747a4af21f2afe8c033e38a8b1207 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_16b5062b7efed3a98a59b7ba59b560b4 = $(`<div id="html_16b5062b7efed3a98a59b7ba59b560b4" style="width: 100.0%; height: 100.0%;">Bolzano (IT) — pop 107,436</div>`)[0];
+                popup_439747a4af21f2afe8c033e38a8b1207.setContent(html_16b5062b7efed3a98a59b7ba59b560b4);
+            
+        
+
+        circle_marker_ea86ab369d9008418d794ea4b9a82aec.bindPopup(popup_439747a4af21f2afe8c033e38a8b1207)
+        ;
+
+        
+    
+    
+            var circle_marker_a047ad70082ff4d60ff41354895efbb6 = L.circleMarker(
+                [46.4984781, 11.3547399],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 12.577442952616051, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_18beaf69b9e1a19c0d562a93b4ae008d = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_5d789bb8224a85b0b3fe83f199128d33 = $(`<div id="html_5d789bb8224a85b0b3fe83f199128d33" style="width: 100.0%; height: 100.0%;">Bolzano - Bozen (IT) — pop 105,713</div>`)[0];
+                popup_18beaf69b9e1a19c0d562a93b4ae008d.setContent(html_5d789bb8224a85b0b3fe83f199128d33);
+            
+        
+
+        circle_marker_a047ad70082ff4d60ff41354895efbb6.bindPopup(popup_18beaf69b9e1a19c0d562a93b4ae008d)
+        ;
+
+        
+    
+    
+            var circle_marker_707b8bea1ba154eea89416e3d7b0ac9d = L.circleMarker(
+                [46.0693, 13.23715],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 12.160274549942802, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_471227f786e22bdce197566c74510ae9 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_cf550d46fa35fa498ec9c17e6eadae1d = $(`<div id="html_cf550d46fa35fa498ec9c17e6eadae1d" style="width: 100.0%; height: 100.0%;">Udine (IT) — pop 100,170</div>`)[0];
+                popup_471227f786e22bdce197566c74510ae9.setContent(html_cf550d46fa35fa498ec9c17e6eadae1d);
+            
+        
+
+        circle_marker_707b8bea1ba154eea89416e3d7b0ac9d.bindPopup(popup_471227f786e22bdce197566c74510ae9)
+        ;
+
+        
+    
+    
+            var circle_marker_d8538c188b63468412dc0b792c56bd8c = L.circleMarker(
+                [46.0634632, 13.2358377],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 12.084938888554397, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_3873631304966c989491d666cfebe7b6 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_acea25418ab285a7dbdf70b7954bc6d2 = $(`<div id="html_acea25418ab285a7dbdf70b7954bc6d2" style="width: 100.0%; height: 100.0%;">Udine / Udin (IT) — pop 99,169</div>`)[0];
+                popup_3873631304966c989491d666cfebe7b6.setContent(html_acea25418ab285a7dbdf70b7954bc6d2);
+            
+        
+
+        circle_marker_d8538c188b63468412dc0b792c56bd8c.bindPopup(popup_3873631304966c989491d666cfebe7b6)
+        ;
+
+        
+    
+    
+            var circle_marker_5ca2d6413acdb39973b0a7f2080578d6 = L.circleMarker(
+                [45.66673, 12.2416],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 11.075772171714132, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_d6c78607930c648922ed1254eb5d808a = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_5d63ea09ab8c151f571e7519376b43bc = $(`<div id="html_5d63ea09ab8c151f571e7519376b43bc" style="width: 100.0%; height: 100.0%;">Treviso (IT) — pop 85,760</div>`)[0];
+                popup_d6c78607930c648922ed1254eb5d808a.setContent(html_5d63ea09ab8c151f571e7519376b43bc);
+            
+        
+
+        circle_marker_5ca2d6413acdb39973b0a7f2080578d6.bindPopup(popup_d6c78607930c648922ed1254eb5d808a)
+        ;
+
+        
+    
+    
+            var circle_marker_8a3c5904cc6d2116272b80b9d92af07d = L.circleMarker(
+                [46.61028, 13.85583],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 9.052923113974352, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_4e3800c2fffa80974d6af9c01d477710 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_291fbf4a1fc2899de425030e7f17a334 = $(`<div id="html_291fbf4a1fc2899de425030e7f17a334" style="width: 100.0%; height: 100.0%;">Villach (AT) — pop 58,882</div>`)[0];
+                popup_4e3800c2fffa80974d6af9c01d477710.setContent(html_291fbf4a1fc2899de425030e7f17a334);
+            
+        
+
+        circle_marker_8a3c5904cc6d2116272b80b9d92af07d.bindPopup(popup_4e3800c2fffa80974d6af9c01d477710)
+        ;
+
+        
+    
+    
+            var circle_marker_5aefe34f20b6573682218161384753af = L.circleMarker(
+                [45.43713, 12.33265],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 8.482148232885784, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_f03156a3544ed7ec43c16fc551fa5bab = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_6d51425a938672a8b000581865a665ec = $(`<div id="html_6d51425a938672a8b000581865a665ec" style="width: 100.0%; height: 100.0%;">Venice (IT) — pop 51,298</div>`)[0];
+                popup_f03156a3544ed7ec43c16fc551fa5bab.setContent(html_6d51425a938672a8b000581865a665ec);
+            
+        
+
+        circle_marker_5aefe34f20b6573682218161384753af.bindPopup(popup_f03156a3544ed7ec43c16fc551fa5bab)
+        ;
+
+        
+    
+    
+            var circle_marker_c9ad69514e0a17e0fdc34e9ef65c9a16 = L.circleMarker(
+                [45.9562503, 12.6597197],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 8.476955265217653, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_a6d43730b569460732d188e6891ad5c7 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_80c0ff8c432e0c8b1176c2df884c2ad1 = $(`<div id="html_80c0ff8c432e0c8b1176c2df884c2ad1" style="width: 100.0%; height: 100.0%;">Pordenone / Pordenon (IT) — pop 51,229</div>`)[0];
+                popup_a6d43730b569460732d188e6891ad5c7.setContent(html_80c0ff8c432e0c8b1176c2df884c2ad1);
+            
+        
+
+        circle_marker_c9ad69514e0a17e0fdc34e9ef65c9a16.bindPopup(popup_a6d43730b569460732d188e6891ad5c7)
+        ;
+
+        
+    
+    
+            var circle_marker_2bb2a127f05dedc57c7f1b36bb3ae91e = L.circleMarker(
+                [45.95689, 12.66051],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 8.375278463483653, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_7909babcda15d8c050fd3404df760063 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_e546faf822084d48725263abb0f95f1b = $(`<div id="html_e546faf822084d48725263abb0f95f1b" style="width: 100.0%; height: 100.0%;">Pordenone (IT) — pop 49,878</div>`)[0];
+                popup_7909babcda15d8c050fd3404df760063.setContent(html_e546faf822084d48725263abb0f95f1b);
+            
+        
+
+        circle_marker_2bb2a127f05dedc57c7f1b36bb3ae91e.bindPopup(popup_7909babcda15d8c050fd3404df760063)
+        ;
+
+        
+    
+    
+            var circle_marker_d41d2372010316c615f535c0f1644c12 = L.circleMarker(
+                [47.41427, 9.74195],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 8.330122222891204, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_1763842c1ffcf14cd447eac9537289dc = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_63d945d00198b916efad201383fa602d = $(`<div id="html_63d945d00198b916efad201383fa602d" style="width: 100.0%; height: 100.0%;">Dornbirn (AT) — pop 49,278</div>`)[0];
+                popup_1763842c1ffcf14cd447eac9537289dc.setContent(html_63d945d00198b916efad201383fa602d);
+            
+        
+
+        circle_marker_d41d2372010316c615f535c0f1644c12.bindPopup(popup_1763842c1ffcf14cd447eac9537289dc)
+        ;
+
+        
+    
+    
+            var circle_marker_3de7239e91779d570356465ba33bba0a = L.circleMarker(
+                [45.4371908, 12.3345898],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 7.923791317960142, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_a562e1f7a32b7ff5258b9ea7964f43e1 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_e30ca9f99110df37a277465869067a31 = $(`<div id="html_e30ca9f99110df37a277465869067a31" style="width: 100.0%; height: 100.0%;">Venezia (IT) — pop 43,879</div>`)[0];
+                popup_a562e1f7a32b7ff5258b9ea7964f43e1.setContent(html_e30ca9f99110df37a277465869067a31);
+            
+        
+
+        circle_marker_3de7239e91779d570356465ba33bba0a.bindPopup(popup_a562e1f7a32b7ff5258b9ea7964f43e1)
+        ;
+
+        
+    
+    
+            var circle_marker_98f5dcd1edff2d650ee8c4c3a37f2e08 = L.circleMarker(
+                [45.7669109, 11.7343469],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 7.885634294659521, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_b435cfacf8d1fc0827e7bc71952ee2a2 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_e89fb5e5020f5ee008f153361df096b9 = $(`<div id="html_e89fb5e5020f5ee008f153361df096b9" style="width: 100.0%; height: 100.0%;">Bassano del Grappa (IT) — pop 43,372</div>`)[0];
+                popup_b435cfacf8d1fc0827e7bc71952ee2a2.setContent(html_e89fb5e5020f5ee008f153361df096b9);
+            
+        
+
+        circle_marker_98f5dcd1edff2d650ee8c4c3a37f2e08.bindPopup(popup_b435cfacf8d1fc0827e7bc71952ee2a2)
+        ;
+
+        
+    
+    
+            var circle_marker_0ea56dc3316d39e0b45f7663cfa57afd = L.circleMarker(
+                [45.63019, 12.5681],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 7.771539526762599, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_49abae53ebebc43cc4a235796dd695f6 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_57c91a9f22e64503e705fe201535d36c = $(`<div id="html_57c91a9f22e64503e705fe201535d36c" style="width: 100.0%; height: 100.0%;">San Donà di Piave (IT) — pop 41,856</div>`)[0];
+                popup_49abae53ebebc43cc4a235796dd695f6.setContent(html_57c91a9f22e64503e705fe201535d36c);
+            
+        
+
+        circle_marker_0ea56dc3316d39e0b45f7663cfa57afd.bindPopup(popup_49abae53ebebc43cc4a235796dd695f6)
+        ;
+
+        
+    
+    
+            var circle_marker_31fc981489b5e27465faf55b35e23d69 = L.circleMarker(
+                [46.66817, 11.15953],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 7.710954903967728, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_c520df4739d5353d51a80278fa2b50e0 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_9eaea7799361105fcdc9ed0e20d21e89 = $(`<div id="html_9eaea7799361105fcdc9ed0e20d21e89" style="width: 100.0%; height: 100.0%;">Merano (IT) — pop 41,051</div>`)[0];
+                popup_c520df4739d5353d51a80278fa2b50e0.setContent(html_9eaea7799361105fcdc9ed0e20d21e89);
+            
+        
+
+        circle_marker_31fc981489b5e27465faf55b35e23d69.bindPopup(popup_c520df4739d5353d51a80278fa2b50e0)
+        ;
+
+        
+    
+    
+            var circle_marker_27de57d7ca423db1da63f30c04173814 = L.circleMarker(
+                [45.7113511, 11.3553593],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 7.58331326389307, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_0dbd2f3f92408348ecb516e4eec6aa4e = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_e3f77dc55d76837eb41a84cb4d0aa1cc = $(`<div id="html_e3f77dc55d76837eb41a84cb4d0aa1cc" style="width: 100.0%; height: 100.0%;">Schio (IT) — pop 39,355</div>`)[0];
+                popup_0dbd2f3f92408348ecb516e4eec6aa4e.setContent(html_e3f77dc55d76837eb41a84cb4d0aa1cc);
+            
+        
+
+        circle_marker_27de57d7ca423db1da63f30c04173814.bindPopup(popup_0dbd2f3f92408348ecb516e4eec6aa4e)
+        ;
+
+        
+    
+    
+            var circle_marker_5a055c4d6a4d7956b714bb893e55f02e = L.circleMarker(
+                [45.886548, 11.0452369],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 7.5783460774279, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_4bbfaa61aea033ed05c6dad29d3cfc9d = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_f9242249741c5daad18970ae026c6eb1 = $(`<div id="html_f9242249741c5daad18970ae026c6eb1" style="width: 100.0%; height: 100.0%;">Rovereto (IT) — pop 39,289</div>`)[0];
+                popup_4bbfaa61aea033ed05c6dad29d3cfc9d.setContent(html_f9242249741c5daad18970ae026c6eb1);
+            
+        
+
+        circle_marker_5a055c4d6a4d7956b714bb893e55f02e.bindPopup(popup_4bbfaa61aea033ed05c6dad29d3cfc9d)
+        ;
+
+        
+    
+    
+            var circle_marker_925430ae2069798d27473bb91be68170 = L.circleMarker(
+                [46.1375185, 12.2181711],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 7.321030766451924, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_04bdb84e99dca7f381a580948c7476d2 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_5a50c8306e3f49e9109d38c9d4c3253f = $(`<div id="html_5a50c8306e3f49e9109d38c9d4c3253f" style="width: 100.0%; height: 100.0%;">Belluno (IT) — pop 35,870</div>`)[0];
+                popup_04bdb84e99dca7f381a580948c7476d2.setContent(html_5a50c8306e3f49e9109d38c9d4c3253f);
+            
+        
+
+        circle_marker_925430ae2069798d27473bb91be68170.bindPopup(popup_04bdb84e99dca7f381a580948c7476d2)
+        ;
+
+        
+    
+    
+            var circle_marker_2a71ac706e2c6538da535e78c237d715 = L.circleMarker(
+                [47.26815, 11.36868],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 7.25879041483533, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_e754f2b1ccc77d42ed9e07498d865560 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_91910f668122b1f843902b1be6637f2e = $(`<div id="html_91910f668122b1f843902b1be6637f2e" style="width: 100.0%; height: 100.0%;">Hötting (AT) — pop 35,043</div>`)[0];
+                popup_e754f2b1ccc77d42ed9e07498d865560.setContent(html_91910f668122b1f843902b1be6637f2e);
+            
+        
+
+        circle_marker_2a71ac706e2c6538da535e78c237d715.bindPopup(popup_e754f2b1ccc77d42ed9e07498d865560)
+        ;
+
+        
+    
+    
+            var circle_marker_ed121040766bf1729e3bd6b76f3997a1 = L.circleMarker(
+                [45.8862172, 12.2977566],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 7.247350833885243, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_14f5dd0fa978e4059be592008db16190 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_74e0fb9963bc4a9208189c6bcc5638d7 = $(`<div id="html_74e0fb9963bc4a9208189c6bcc5638d7" style="width: 100.0%; height: 100.0%;">Conegliano (IT) — pop 34,891</div>`)[0];
+                popup_14f5dd0fa978e4059be592008db16190.setContent(html_74e0fb9963bc4a9208189c6bcc5638d7);
+            
+        
+
+        circle_marker_ed121040766bf1729e3bd6b76f3997a1.bindPopup(popup_14f5dd0fa978e4059be592008db16190)
+        ;
+
+        
+    
+    
+            var circle_marker_866399f04ffbe713c990c73429c4ddba = L.circleMarker(
+                [45.94088, 13.62167],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 7.212505268228069, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_b34d65179d1b333c27882e7f24ffd0c5 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_95d249b8ae2afa7e8592baef8a236be7 = $(`<div id="html_95d249b8ae2afa7e8592baef8a236be7" style="width: 100.0%; height: 100.0%;">Gorizia (IT) — pop 34,428</div>`)[0];
+                popup_b34d65179d1b333c27882e7f24ffd0c5.setContent(html_95d249b8ae2afa7e8592baef8a236be7);
+            
+        
+
+        circle_marker_866399f04ffbe713c990c73429c4ddba.bindPopup(popup_b34d65179d1b333c27882e7f24ffd0c5)
+        ;
+
+        
+    
+    
+            var circle_marker_ee86858f65a2b5f78535684260c9e3b2 = L.circleMarker(
+                [46.6695547, 11.1594185],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 7.154404238665784, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_06b945f9836febcffdf28694e234a73a = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_28181d9a0d27de07dad081a244922276 = $(`<div id="html_28181d9a0d27de07dad081a244922276" style="width: 100.0%; height: 100.0%;">Merano - Meran (IT) — pop 33,656</div>`)[0];
+                popup_06b945f9836febcffdf28694e234a73a.setContent(html_28181d9a0d27de07dad081a244922276);
+            
+        
+
+        circle_marker_ee86858f65a2b5f78535684260c9e3b2.bindPopup(popup_06b945f9836febcffdf28694e234a73a)
+        ;
+
+        
+    
+    
+            var circle_marker_b8f0098af89a9cc2a764159d9ece96fe = L.circleMarker(
+                [47.23306, 9.6],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 7.1366427840327535, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_e83390bc5f22159b62ca966b1cfe919c = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_14afce71cbc03dbd01d057572c3cad67 = $(`<div id="html_14afce71cbc03dbd01d057572c3cad67" style="width: 100.0%; height: 100.0%;">Feldkirch (AT) — pop 33,420</div>`)[0];
+                popup_e83390bc5f22159b62ca966b1cfe919c.setContent(html_14afce71cbc03dbd01d057572c3cad67);
+            
+        
+
+        circle_marker_b8f0098af89a9cc2a764159d9ece96fe.bindPopup(popup_e83390bc5f22159b62ca966b1cfe919c)
+        ;
+
+        
+    
+    
+            var circle_marker_529755904d90f67705206bf62fc6bd5a = L.circleMarker(
+                [45.671139, 11.9265624],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 7.122644349449094, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_11b9887d8c0239e58ac3d4b4dcdba291 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_5b28e2d7044e3eb7f9576025cd80fb8e = $(`<div id="html_5b28e2d7044e3eb7f9576025cd80fb8e" style="width: 100.0%; height: 100.0%;">Castelfranco Veneto (IT) — pop 33,234</div>`)[0];
+                popup_11b9887d8c0239e58ac3d4b4dcdba291.setContent(html_5b28e2d7044e3eb7f9576025cd80fb8e);
+            
+        
+
+        circle_marker_529755904d90f67705206bf62fc6bd5a.bindPopup(popup_11b9887d8c0239e58ac3d4b4dcdba291)
+        ;
+
+        
+    
+    
+            var circle_marker_fd53d5eedceae1f99352f6c46d849bca = L.circleMarker(
+                [45.4346, 12.12942],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 7.096077427900536, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_cc2e36b833093216a514616fb4acb116 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_2ee8008a6feb0110fbd902729f82eff0 = $(`<div id="html_2ee8008a6feb0110fbd902729f82eff0" style="width: 100.0%; height: 100.0%;">Mira (IT) — pop 32,881</div>`)[0];
+                popup_cc2e36b833093216a514616fb4acb116.setContent(html_2ee8008a6feb0110fbd902729f82eff0);
+            
+        
+
+        circle_marker_fd53d5eedceae1f99352f6c46d849bca.bindPopup(popup_cc2e36b833093216a514616fb4acb116)
+        ;
+
+        
+    
+    
+            var circle_marker_50c737c4d4d8c25493d258128f387b7b = L.circleMarker(
+                [47.26539, 11.4152],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 7.074026130411223, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_40809a3335ab1ebe9b5e1b5f99ba15e9 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_7aeceeef9147aed8c98d21fded5e8de8 = $(`<div id="html_7aeceeef9147aed8c98d21fded5e8de8" style="width: 100.0%; height: 100.0%;">Pradl (AT) — pop 32,588</div>`)[0];
+                popup_40809a3335ab1ebe9b5e1b5f99ba15e9.setContent(html_7aeceeef9147aed8c98d21fded5e8de8);
+            
+        
+
+        circle_marker_50c737c4d4d8c25493d258128f387b7b.bindPopup(popup_40809a3335ab1ebe9b5e1b5f99ba15e9)
+        ;
+
+        
+    
+    
+            var circle_marker_a7334064ba1b12af90c090c18c29831e = L.circleMarker(
+                [45.7762844, 12.0452878],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 6.971671985068337, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_5de125be36cba2ae19d9edc27b0e320c = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_81ce26d78c1f1db04b03651bf007f69b = $(`<div id="html_81ce26d78c1f1db04b03651bf007f69b" style="width: 100.0%; height: 100.0%;">Montebelluna (IT) — pop 31,228</div>`)[0];
+                popup_5de125be36cba2ae19d9edc27b0e320c.setContent(html_81ce26d78c1f1db04b03651bf007f69b);
+            
+        
+
+        circle_marker_a7334064ba1b12af90c090c18c29831e.bindPopup(popup_5de125be36cba2ae19d9edc27b0e320c)
+        ;
+
+        
+    
+    
+            var circle_marker_c4cba75ca9f610c2bf2af044bc541149 = L.circleMarker(
+                [47.50311, 9.7471],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 6.86465169486423, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_18ec19291bb57e598f1182388dfbcf8d = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_5812fdec8a2e95b619d0296363dce9e1 = $(`<div id="html_5812fdec8a2e95b619d0296363dce9e1" style="width: 100.0%; height: 100.0%;">Bregenz (AT) — pop 29,806</div>`)[0];
+                popup_18ec19291bb57e598f1182388dfbcf8d.setContent(html_5812fdec8a2e95b619d0296363dce9e1);
+            
+        
+
+        circle_marker_c4cba75ca9f610c2bf2af044bc541149.bindPopup(popup_18ec19291bb57e598f1182388dfbcf8d)
+        ;
+
+        
+    
+    
+            var circle_marker_67042c248ef02e2f354de86fc3e1ad49 = L.circleMarker(
+                [45.45111, 12.22389],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 6.7755433800951295, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_b789ee02a133844362e6c4bbe993e1ae = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_16da93369f72cf00282c9cd30c025f62 = $(`<div id="html_16da93369f72cf00282c9cd30c025f62" style="width: 100.0%; height: 100.0%;">Marghera (IT) — pop 28,622</div>`)[0];
+                popup_b789ee02a133844362e6c4bbe993e1ae.setContent(html_16da93369f72cf00282c9cd30c025f62);
+            
+        
+
+        circle_marker_67042c248ef02e2f354de86fc3e1ad49.bindPopup(popup_b789ee02a133844362e6c4bbe993e1ae)
+        ;
+
+        
+    
+    
+            var circle_marker_f7a2d975bf043fa02be79ba1d0a2119a = L.circleMarker(
+                [45.9897826, 12.2957596],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 6.746191823710037, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_74c4fcff276ec6fca02eacc0e9822e7a = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_1c05726606d3d06ba3e3798f75cff73b = $(`<div id="html_1c05726606d3d06ba3e3798f75cff73b" style="width: 100.0%; height: 100.0%;">Vittorio Veneto (IT) — pop 28,232</div>`)[0];
+                popup_74c4fcff276ec6fca02eacc0e9822e7a.setContent(html_1c05726606d3d06ba3e3798f75cff73b);
+            
+        
+
+        circle_marker_f7a2d975bf043fa02be79ba1d0a2119a.bindPopup(popup_74c4fcff276ec6fca02eacc0e9822e7a)
+        ;
+
+        
+    
+    
+            var circle_marker_0d243c69f4f266e6aaba652e96573be3 = L.circleMarker(
+                [45.4911604, 12.165018],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 6.723237401408875, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_d64ac661e081ac8cf1c768b5e9871b67 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_07f2c1de6a4c2ea077b7a25ad72c9319 = $(`<div id="html_07f2c1de6a4c2ea077b7a25ad72c9319" style="width: 100.0%; height: 100.0%;">Spinea (IT) — pop 27,927</div>`)[0];
+                popup_d64ac661e081ac8cf1c768b5e9871b67.setContent(html_07f2c1de6a4c2ea077b7a25ad72c9319);
+            
+        
+
+        circle_marker_0d243c69f4f266e6aaba652e96573be3.bindPopup(popup_d64ac661e081ac8cf1c768b5e9871b67)
+        ;
+
+        
+    
+    
+            var circle_marker_5553e04faaf4840d4480e3b22b2f4103 = L.circleMarker(
+                [45.5612886, 12.2376973],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 6.703067613944247, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_c7f301b3add7b683f72b1d89d3888430 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_5fa52c71a71e24ef43b5251791696981 = $(`<div id="html_5fa52c71a71e24ef43b5251791696981" style="width: 100.0%; height: 100.0%;">Mogliano Veneto (IT) — pop 27,659</div>`)[0];
+                popup_c7f301b3add7b683f72b1d89d3888430.setContent(html_5fa52c71a71e24ef43b5251791696981);
+            
+        
+
+        circle_marker_5553e04faaf4840d4480e3b22b2f4103.bindPopup(popup_c7f301b3add7b683f72b1d89d3888430)
+        ;
+
+        
+    
+    
+            var circle_marker_05a6e0dc4f7c465ffdba1a4719b66e2d = L.circleMarker(
+                [45.492993, 12.1094168],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 6.6568577277379735, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_e9ee48567648eef7dde2c7b86301713c = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_cef67d22036922b0f70f393a3b200b4e = $(`<div id="html_cef67d22036922b0f70f393a3b200b4e" style="width: 100.0%; height: 100.0%;">Mirano (IT) — pop 27,045</div>`)[0];
+                popup_e9ee48567648eef7dde2c7b86301713c.setContent(html_cef67d22036922b0f70f393a3b200b4e);
+            
+        
+
+        circle_marker_05a6e0dc4f7c465ffdba1a4719b66e2d.bindPopup(popup_e9ee48567648eef7dde2c7b86301713c)
+        ;
+
+        
+    
+    
+            var circle_marker_5c458e12c3a38635fb6ba94adaff73eb = L.circleMarker(
+                [45.80463, 13.53292],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 6.631344451803239, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_431054fa382ee68d1c7f81f8ebabe323 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_778c69039bcb4b01542c493b3e831107 = $(`<div id="html_778c69039bcb4b01542c493b3e831107" style="width: 100.0%; height: 100.0%;">Monfalcone (IT) — pop 26,706</div>`)[0];
+                popup_431054fa382ee68d1c7f81f8ebabe323.setContent(html_778c69039bcb4b01542c493b3e831107);
+            
+        
+
+        circle_marker_5c458e12c3a38635fb6ba94adaff73eb.bindPopup(popup_431054fa382ee68d1c7f81f8ebabe323)
+        ;
+
+        
+    
+    
+            var circle_marker_bf727b2e3b4cc65467272a8d619bc7d0 = L.circleMarker(
+                [45.6413213, 11.3040596],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 6.595821542537179, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_49f7637433b2e9c1bb1112ddcbeb6175 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_86491ccabbb59a8d42be7f800f7e3c65 = $(`<div id="html_86491ccabbb59a8d42be7f800f7e3c65" style="width: 100.0%; height: 100.0%;">Valdagno (IT) — pop 26,234</div>`)[0];
+                popup_49f7637433b2e9c1bb1112ddcbeb6175.setContent(html_86491ccabbb59a8d42be7f800f7e3c65);
+            
+        
+
+        circle_marker_bf727b2e3b4cc65467272a8d619bc7d0.bindPopup(popup_49f7637433b2e9c1bb1112ddcbeb6175)
+        ;
+
+        
+    
+    
+            var circle_marker_e12477ae656c9ae94fe810643f504c08 = L.circleMarker(
+                [45.5367094, 12.6383337],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 6.587392377626588, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_07b03a64989b37872f1d08ea8c2d16fe = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_70b9b70b81caaa259dcd72f72f184904 = $(`<div id="html_70b9b70b81caaa259dcd72f72f184904" style="width: 100.0%; height: 100.0%;">Jesolo (IT) — pop 26,122</div>`)[0];
+                popup_07b03a64989b37872f1d08ea8c2d16fe.setContent(html_70b9b70b81caaa259dcd72f72f184904);
+            
+        
+
+        circle_marker_e12477ae656c9ae94fe810643f504c08.bindPopup(popup_07b03a64989b37872f1d08ea8c2d16fe)
+        ;
+
+        
+    
+    
+            var circle_marker_8e26675882db7c314cedaa996b1d498e = L.circleMarker(
+                [47.4923741, 11.0962815],
+                {"bubblingMouseEvents": true, "color": "blue", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "blue", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 6.58588716960684, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_eef4f0e83c971b48c01f236098b358ea = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_c3e8315151da2200b05470aa6ee5ff75 = $(`<div id="html_c3e8315151da2200b05470aa6ee5ff75" style="width: 100.0%; height: 100.0%;">Garmisch-Partenkirchen (DE) — pop 26,102</div>`)[0];
+                popup_eef4f0e83c971b48c01f236098b358ea.setContent(html_c3e8315151da2200b05470aa6ee5ff75);
+            
+        
+
+        circle_marker_8e26675882db7c314cedaa996b1d498e.bindPopup(popup_eef4f0e83c971b48c01f236098b358ea)
+        ;
+
+        
+    
+    
+            var circle_marker_84646c2ee6fdfd7e29189099bdaf6fbf = L.circleMarker(
+                [45.775598, 12.8374571],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 6.51363718465892, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_e5a3e18bf676ffe7c74fb553063fbff4 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_9cc738c41ac1273851526743d77dcba7 = $(`<div id="html_9cc738c41ac1273851526743d77dcba7" style="width: 100.0%; height: 100.0%;">Portogruaro (IT) — pop 25,142</div>`)[0];
+                popup_e5a3e18bf676ffe7c74fb553063fbff4.setContent(html_9cc738c41ac1273851526743d77dcba7);
+            
+        
+
+        circle_marker_84646c2ee6fdfd7e29189099bdaf6fbf.bindPopup(popup_e5a3e18bf676ffe7c74fb553063fbff4)
+        ;
+
+        
+    
+    
+            var circle_marker_68e0827058095d034ed4bfe0dfc58db9 = L.circleMarker(
+                [45.7059893, 11.4797197],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 6.432130170389548, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_ab9443a0ae977b5807b651cccca75d9f = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_33083761e77a350415a474996286cfd6 = $(`<div id="html_33083761e77a350415a474996286cfd6" style="width: 100.0%; height: 100.0%;">Thiene (IT) — pop 24,059</div>`)[0];
+                popup_ab9443a0ae977b5807b651cccca75d9f.setContent(html_33083761e77a350415a474996286cfd6);
+            
+        
+
+        circle_marker_68e0827058095d034ed4bfe0dfc58db9.bindPopup(popup_ab9443a0ae977b5807b651cccca75d9f)
+        ;
+
+        
+    
+    
+            var circle_marker_a38b1a934360afb9b7fd49f4f4dfa384 = L.circleMarker(
+                [46.716413, 11.657792],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 6.352730447347824, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_7ece88ed6c806d140abfa9dd4dd861a1 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_f38e40bf0c86a1b46d132465b98fe343 = $(`<div id="html_f38e40bf0c86a1b46d132465b98fe343" style="width: 100.0%; height: 100.0%;">Brixen - Bressanone (IT) — pop 23,004</div>`)[0];
+                popup_7ece88ed6c806d140abfa9dd4dd861a1.setContent(html_f38e40bf0c86a1b46d132465b98fe343);
+            
+        
+
+        circle_marker_a38b1a934360afb9b7fd49f4f4dfa384.bindPopup(popup_7ece88ed6c806d140abfa9dd4dd861a1)
+        ;
+
+        
+    
+    
+            var circle_marker_370bf5cfcf9d473bab209d742f7b6f3c = L.circleMarker(
+                [47.42642, 9.65851],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 6.338957793967126, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_d6df2f1d23d19a07940b0aecaaa909c2 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_a3a9ac27b828656a01b2ffb003c49935 = $(`<div id="html_a3a9ac27b828656a01b2ffb003c49935" style="width: 100.0%; height: 100.0%;">Lustenau (AT) — pop 22,821</div>`)[0];
+                popup_d6df2f1d23d19a07940b0aecaaa909c2.setContent(html_a3a9ac27b828656a01b2ffb003c49935);
+            
+        
+
+        circle_marker_370bf5cfcf9d473bab209d742f7b6f3c.bindPopup(popup_d6df2f1d23d19a07940b0aecaaa909c2)
+        ;
+
+        
+    
+    
+            var circle_marker_388201a6a4bb4668542773cc781f73e4 = L.circleMarker(
+                [45.443016, 11.983089],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 6.333463784695045, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_43510eacf777db9c069f1b58093a9147 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_960c199783ca081cf374c81f230c02cf = $(`<div id="html_960c199783ca081cf374c81f230c02cf" style="width: 100.0%; height: 100.0%;">Vigonza (IT) — pop 22,748</div>`)[0];
+                popup_43510eacf777db9c069f1b58093a9147.setContent(html_960c199783ca081cf374c81f230c02cf);
+            
+        
+
+        circle_marker_388201a6a4bb4668542773cc781f73e4.bindPopup(popup_43510eacf777db9c069f1b58093a9147)
+        ;
+
+        
+    
+    
+            var circle_marker_8a2c22efb740b398213a00437a756c12 = L.circleMarker(
+                [45.6727307, 12.1536106],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 6.274760671924859, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_7283e4e83c485ee04fce108d2f604d79 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_45b4d058024b48db8624ad385cbd692e = $(`<div id="html_45b4d058024b48db8624ad385cbd692e" style="width: 100.0%; height: 100.0%;">Paese (IT) — pop 21,968</div>`)[0];
+                popup_7283e4e83c485ee04fce108d2f604d79.setContent(html_45b4d058024b48db8624ad385cbd692e);
+            
+        
+
+        circle_marker_8a2c22efb740b398213a00437a756c12.bindPopup(popup_7283e4e83c485ee04fce108d2f604d79)
+        ;
+
+        
+    
+    
+            var circle_marker_adf7449cf7b719334a9d2c5947c95ddd = L.circleMarker(
+                [45.5466448, 12.1576784],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 6.241646095490397, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_bd51f0e639aec912e99b51a8dbcd9965 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_a682bc1f8ce9789b6c38f1b36e00f496 = $(`<div id="html_a682bc1f8ce9789b6c38f1b36e00f496" style="width: 100.0%; height: 100.0%;">Martellago (IT) — pop 21,528</div>`)[0];
+                popup_bd51f0e639aec912e99b51a8dbcd9965.setContent(html_a682bc1f8ce9789b6c38f1b36e00f496);
+            
+        
+
+        circle_marker_adf7449cf7b719334a9d2c5947c95ddd.bindPopup(popup_bd51f0e639aec912e99b51a8dbcd9965)
+        ;
+
+        
+    
+    
+            var circle_marker_9d53d88b032f8baf3852e316d779b2c4 = L.circleMarker(
+                [47.51821, 10.28262],
+                {"bubblingMouseEvents": true, "color": "blue", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "blue", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 6.223357818050454, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_b9aba6eb5cacc29bb93e9ea6125e50bb = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_22dda5717fa55b66648a4ee3f470c41d = $(`<div id="html_22dda5717fa55b66648a4ee3f470c41d" style="width: 100.0%; height: 100.0%;">Sonthofen (DE) — pop 21,285</div>`)[0];
+                popup_b9aba6eb5cacc29bb93e9ea6125e50bb.setContent(html_22dda5717fa55b66648a4ee3f470c41d);
+            
+        
+
+        circle_marker_9d53d88b032f8baf3852e316d779b2c4.bindPopup(popup_b9aba6eb5cacc29bb93e9ea6125e50bb)
+        ;
+
+        
+    
+    
+            var circle_marker_717d7a35ec93bdd9c233e6f558555b77 = L.circleMarker(
+                [46.0605291, 11.2406747],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 6.222981516045517, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_cdbfc2c379e30e5dde6c1b43ef337b2b = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_3c1b3862ecbb7305adc7dee4f9658449 = $(`<div id="html_3c1b3862ecbb7305adc7dee4f9658449" style="width: 100.0%; height: 100.0%;">Pergine Valsugana (IT) — pop 21,280</div>`)[0];
+                popup_cdbfc2c379e30e5dde6c1b43ef337b2b.setContent(html_3c1b3862ecbb7305adc7dee4f9658449);
+            
+        
+
+        circle_marker_717d7a35ec93bdd9c233e6f558555b77.bindPopup(popup_cdbfc2c379e30e5dde6c1b43ef337b2b)
+        ;
+
+        
+    
+    
+            var circle_marker_b04dd6e2ebd252e47e3ba131d69470fd = L.circleMarker(
+                [46.0163755, 11.9062541],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 6.175492203022458, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_1332107ad28db717e1801f8aa68510c1 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_eab297e9d25adee62e6c33eb38b7fa32 = $(`<div id="html_eab297e9d25adee62e6c33eb38b7fa32" style="width: 100.0%; height: 100.0%;">Feltre (IT) — pop 20,649</div>`)[0];
+                popup_1332107ad28db717e1801f8aa68510c1.setContent(html_eab297e9d25adee62e6c33eb38b7fa32);
+            
+        
+
+        circle_marker_b04dd6e2ebd252e47e3ba131d69470fd.bindPopup(popup_1332107ad28db717e1801f8aa68510c1)
+        ;
+
+        
+    
+    
+            var circle_marker_dd941374b9635f0e40fa8a5f0225ed8d = L.circleMarker(
+                [45.7833709, 12.4937783],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 6.155171894755855, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_81eea1add5ecec69b00f7c72d53f0483 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_13191b7af185607ca92feeb7a18224a1 = $(`<div id="html_13191b7af185607ca92feeb7a18224a1" style="width: 100.0%; height: 100.0%;">Oderzo (IT) — pop 20,379</div>`)[0];
+                popup_81eea1add5ecec69b00f7c72d53f0483.setContent(html_13191b7af185607ca92feeb7a18224a1);
+            
+        
+
+        circle_marker_dd941374b9635f0e40fa8a5f0225ed8d.bindPopup(popup_81eea1add5ecec69b00f7c72d53f0483)
+        ;
+
+        
+    
+    
+            var circle_marker_2b9ae499b196b69b445c3ba43a70db01 = L.circleMarker(
+                [45.6487941, 11.7835801],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 6.138313564934673, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_5ba33ff7641784b1bb516a86bf7a54b3 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_d7271a92a37c3eab2a8f2c5f9b199c4d = $(`<div id="html_d7271a92a37c3eab2a8f2c5f9b199c4d" style="width: 100.0%; height: 100.0%;">Cittadella (IT) — pop 20,155</div>`)[0];
+                popup_5ba33ff7641784b1bb516a86bf7a54b3.setContent(html_d7271a92a37c3eab2a8f2c5f9b199c4d);
+            
+        
+
+        circle_marker_2b9ae499b196b69b445c3ba43a70db01.bindPopup(popup_5ba33ff7641784b1bb516a86bf7a54b3)
+        ;
+
+        
+    
+    
+            var circle_marker_61863ade1baa8b3f922a6e7ccf1e3b65 = L.circleMarker(
+                [46.61667, 14.28333],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 6.126648202781624, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_35077766ade3876384755bfd8534882e = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_3d0895ac8d9fd26c7a9e42b6b1a3d9bf = $(`<div id="html_3d0895ac8d9fd26c7a9e42b6b1a3d9bf" style="width: 100.0%; height: 100.0%;">Sankt Martin (AT) — pop 20,000</div>`)[0];
+                popup_35077766ade3876384755bfd8534882e.setContent(html_3d0895ac8d9fd26c7a9e42b6b1a3d9bf);
+            
+        
+
+        circle_marker_61863ade1baa8b3f922a6e7ccf1e3b65.bindPopup(popup_35077766ade3876384755bfd8534882e)
+        ;
+
+        
+    
+    
+            var circle_marker_949cb74b4a81d3bb85900aa486140971 = L.circleMarker(
+                [45.9548046, 12.5034415],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 6.114380757420675, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_178bd5fa73d6ea41619d3b3743c5e258 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_4e605926f801d6441647228326ff255f = $(`<div id="html_4e605926f801d6441647228326ff255f" style="width: 100.0%; height: 100.0%;">Sacile / Sacîl (IT) — pop 19,837</div>`)[0];
+                popup_178bd5fa73d6ea41619d3b3743c5e258.setContent(html_4e605926f801d6441647228326ff255f);
+            
+        
+
+        circle_marker_949cb74b4a81d3bb85900aa486140971.bindPopup(popup_178bd5fa73d6ea41619d3b3743c5e258)
+        ;
+
+        
+    
+    
+            var circle_marker_8016666e7fe644a2199e903330754fec = L.circleMarker(
+                [46.06251, 6.57497],
+                {"bubblingMouseEvents": true, "color": "green", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "green", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 6.110768258173279, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_62c676e0cf4d4e7192ae85bf51d8ea15 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_018abdb631cabb95abfbb2dcc5accef3 = $(`<div id="html_018abdb631cabb95abfbb2dcc5accef3" style="width: 100.0%; height: 100.0%;">Cluses (FR) — pop 19,789</div>`)[0];
+                popup_62c676e0cf4d4e7192ae85bf51d8ea15.setContent(html_018abdb631cabb95abfbb2dcc5accef3);
+            
+        
+
+        circle_marker_8016666e7fe644a2199e903330754fec.bindPopup(popup_62c676e0cf4d4e7192ae85bf51d8ea15)
+        ;
+
+        
+    
+    
+            var circle_marker_400c274145df24a23ae9ea682c6397f4 = L.circleMarker(
+                [46.16852, 9.87134],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 6.067041965199591, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_544b4fba9072246d9a90266a01613c0b = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_9eb5c0da90bd59428759cc3ca606c31f = $(`<div id="html_9eb5c0da90bd59428759cc3ca606c31f" style="width: 100.0%; height: 100.0%;">Sondrio (IT) — pop 19,208</div>`)[0];
+                popup_544b4fba9072246d9a90266a01613c0b.setContent(html_9eb5c0da90bd59428759cc3ca606c31f);
+            
+        
+
+        circle_marker_400c274145df24a23ae9ea682c6397f4.bindPopup(popup_544b4fba9072246d9a90266a01613c0b)
+        ;
+
+        
+    
+    
+            var circle_marker_582a1ff48c4615874e5a0be3905c626e = L.circleMarker(
+                [45.5713541, 12.108383],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 6.041077126858932, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_f1560bac3bfaf7e5e78686649dfd1f41 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_af49f6087b872f1d81b738f3d6e4054c = $(`<div id="html_af49f6087b872f1d81b738f3d6e4054c" style="width: 100.0%; height: 100.0%;">Scorzè (IT) — pop 18,863</div>`)[0];
+                popup_f1560bac3bfaf7e5e78686649dfd1f41.setContent(html_af49f6087b872f1d81b738f3d6e4054c);
+            
+        
+
+        circle_marker_582a1ff48c4615874e5a0be3905c626e.bindPopup(popup_f1560bac3bfaf7e5e78686649dfd1f41)
+        ;
+
+        
+    
+    
+            var circle_marker_d61d21e11c665757db6d867bf1fcbcc1 = L.circleMarker(
+                [47.25829, 11.38808],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.986814377747004, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_87b2f28f3367dc2a94832d743dbe2161 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_1ccbf06c2b9f017cbf37109d01d945b4 = $(`<div id="html_1ccbf06c2b9f017cbf37109d01d945b4" style="width: 100.0%; height: 100.0%;">Wilten (AT) — pop 18,142</div>`)[0];
+                popup_87b2f28f3367dc2a94832d743dbe2161.setContent(html_1ccbf06c2b9f017cbf37109d01d945b4);
+            
+        
+
+        circle_marker_d61d21e11c665757db6d867bf1fcbcc1.bindPopup(popup_87b2f28f3367dc2a94832d743dbe2161)
+        ;
+
+        
+    
+    
+            var circle_marker_8ccc7752e176899b370418137ee5cf18 = L.circleMarker(
+                [45.9181327, 10.8860953],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.940453970738756, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_51aa6d0b1d8d153f4d391ec44c56a66c = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_f846307139fad68ac4abf4f9e4dec6b8 = $(`<div id="html_f846307139fad68ac4abf4f9e4dec6b8" style="width: 100.0%; height: 100.0%;">Arco (IT) — pop 17,526</div>`)[0];
+                popup_51aa6d0b1d8d153f4d391ec44c56a66c.setContent(html_f846307139fad68ac4abf4f9e4dec6b8);
+            
+        
+
+        circle_marker_8ccc7752e176899b370418137ee5cf18.bindPopup(popup_51aa6d0b1d8d153f4d391ec44c56a66c)
+        ;
+
+        
+    
+    
+            var circle_marker_a90bb72693dd4a8ba19bca1b4481b842 = L.circleMarker(
+                [45.5543521, 12.2993285],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.929465952194594, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_38c13ddeba9f0784c4b317dc0cb57ea5 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_7fc139dea52b94eb3bc4549375676fbc = $(`<div id="html_7fc139dea52b94eb3bc4549375676fbc" style="width: 100.0%; height: 100.0%;">Marcon (IT) — pop 17,380</div>`)[0];
+                popup_38c13ddeba9f0784c4b317dc0cb57ea5.setContent(html_7fc139dea52b94eb3bc4549375676fbc);
+            
+        
+
+        circle_marker_a90bb72693dd4a8ba19bca1b4481b842.bindPopup(popup_38c13ddeba9f0784c4b317dc0cb57ea5)
+        ;
+
+        
+    
+    
+            var circle_marker_be670b74720fa45c72de46f1825473ad = L.circleMarker(
+                [45.88577, 10.84117],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.925778192546209, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_dd852dbaffa0d87df97ec64fbbe7cde9 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_499a3d630703ea51774602d40bcad10d = $(`<div id="html_499a3d630703ea51774602d40bcad10d" style="width: 100.0%; height: 100.0%;">Riva del Garda (IT) — pop 17,331</div>`)[0];
+                popup_dd852dbaffa0d87df97ec64fbbe7cde9.setContent(html_499a3d630703ea51774602d40bcad10d);
+            
+        
+
+        circle_marker_be670b74720fa45c72de46f1825473ad.bindPopup(popup_dd852dbaffa0d87df97ec64fbbe7cde9)
+        ;
+
+        
+    
+    
+            var circle_marker_b42cdb515e17bda3a1f7b8aa2ffeb020 = L.circleMarker(
+                [45.6867631, 12.0188471],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.891308928893973, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_ffdc14bb4d8b39dcee80842891642f7e = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_0730f42c913ade9db8fb13adbd679535 = $(`<div id="html_0730f42c913ade9db8fb13adbd679535" style="width: 100.0%; height: 100.0%;">Vedelago (IT) — pop 16,873</div>`)[0];
+                popup_ffdc14bb4d8b39dcee80842891642f7e.setContent(html_0730f42c913ade9db8fb13adbd679535);
+            
+        
+
+        circle_marker_b42cdb515e17bda3a1f7b8aa2ffeb020.bindPopup(popup_ffdc14bb4d8b39dcee80842891642f7e)
+        ;
+
+        
+    
+    
+            var circle_marker_37468c9646521f78cb16419536748948 = L.circleMarker(
+                [45.94423, 6.63162],
+                {"bubblingMouseEvents": true, "color": "green", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "green", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.880170389547835, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_84ad06c0d97dde4b341a6c5834ca7c67 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_0038301dc02dc7011839f86e1557749d = $(`<div id="html_0038301dc02dc7011839f86e1557749d" style="width: 100.0%; height: 100.0%;">Sallanches (FR) — pop 16,725</div>`)[0];
+                popup_84ad06c0d97dde4b341a6c5834ca7c67.setContent(html_0038301dc02dc7011839f86e1557749d);
+            
+        
+
+        circle_marker_37468c9646521f78cb16419536748948.bindPopup(popup_84ad06c0d97dde4b341a6c5834ca7c67)
+        ;
+
+        
+    
+    
+            var circle_marker_0f486f8b8bdc0f9f69457851de0eeb75 = L.circleMarker(
+                [45.6025304, 12.2353136],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.8785899211271, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_43ac3958166ab10412310a18cb7a19c3 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_81fec921e10d61ac400f29795b30fea2 = $(`<div id="html_81fec921e10d61ac400f29795b30fea2" style="width: 100.0%; height: 100.0%;">Preganziol (IT) — pop 16,704</div>`)[0];
+                popup_43ac3958166ab10412310a18cb7a19c3.setContent(html_81fec921e10d61ac400f29795b30fea2);
+            
+        
+
+        circle_marker_0f486f8b8bdc0f9f69457851de0eeb75.bindPopup(popup_43ac3958166ab10412310a18cb7a19c3)
+        ;
+
+        
+    
+    
+            var circle_marker_b2def2ef47715404bfa5f12d387628da = L.circleMarker(
+                [45.95412, 12.50274],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.872719609850082, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_98b4d0106777dc29e98c79482fa4b063 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_c398b53996673b4cc203df2168c66062 = $(`<div id="html_c398b53996673b4cc203df2168c66062" style="width: 100.0%; height: 100.0%;">Sacile (IT) — pop 16,626</div>`)[0];
+                popup_98b4d0106777dc29e98c79482fa4b063.setContent(html_c398b53996673b4cc203df2168c66062);
+            
+        
+
+        circle_marker_b2def2ef47715404bfa5f12d387628da.bindPopup(popup_98b4d0106777dc29e98c79482fa4b063)
+        ;
+
+        
+    
+    
+            var circle_marker_c0764bacf270970c9a5514c4fcb20f24 = L.circleMarker(
+                [47.36121, 9.68694],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.849464145944969, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_6a3fdf1e10e23b87fff63641d9fb6d1c = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_33341522031c2b9847e8f11b66ecd940 = $(`<div id="html_33341522031c2b9847e8f11b66ecd940" style="width: 100.0%; height: 100.0%;">Hohenems (AT) — pop 16,317</div>`)[0];
+                popup_6a3fdf1e10e23b87fff63641d9fb6d1c.setContent(html_33341522031c2b9847e8f11b66ecd940);
+            
+        
+
+        circle_marker_c0764bacf270970c9a5514c4fcb20f24.bindPopup(popup_6a3fdf1e10e23b87fff63641d9fb6d1c)
+        ;
+
+        
+    
+    
+            var circle_marker_e356fef04ed1dcb6e55b1e108e26f096 = L.circleMarker(
+                [45.550156, 12.0720437],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.823273526401349, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_835295bd4a71ccb6563db28317505c96 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_95cf0de4b37c1fced3f4dc4435b619e8 = $(`<div id="html_95cf0de4b37c1fced3f4dc4435b619e8" style="width: 100.0%; height: 100.0%;">Noale (IT) — pop 15,969</div>`)[0];
+                popup_835295bd4a71ccb6563db28317505c96.setContent(html_95cf0de4b37c1fced3f4dc4435b619e8);
+            
+        
+
+        circle_marker_e356fef04ed1dcb6e55b1e108e26f096.bindPopup(popup_835295bd4a71ccb6563db28317505c96)
+        ;
+
+        
+    
+    
+            var circle_marker_468714660495c78bf1700f573c465db8 = L.circleMarker(
+                [45.9836, 12.70038],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.8227467035944365, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_ec4915c9bfad2b8ea8d2bff0f5e8c939 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_f8b3b57d62ea3689b2e3cc9dc118dc00 = $(`<div id="html_f8b3b57d62ea3689b2e3cc9dc118dc00" style="width: 100.0%; height: 100.0%;">Cordenons (IT) — pop 15,962</div>`)[0];
+                popup_ec4915c9bfad2b8ea8d2bff0f5e8c939.setContent(html_f8b3b57d62ea3689b2e3cc9dc118dc00);
+            
+        
+
+        circle_marker_468714660495c78bf1700f573c465db8.bindPopup(popup_ec4915c9bfad2b8ea8d2bff0f5e8c939)
+        ;
+
+        
+    
+    
+            var circle_marker_0fd1a7ba0190cbc99ec10f1286592d4b = L.circleMarker(
+                [47.3046511, 11.071515],
+                {"bubblingMouseEvents": true, "color": "blue", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "blue", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.819585766752965, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_ec99f8aaccb95d641be1964cbfc80894 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_339c03d6d31f4f22a84009d32ddb8672 = $(`<div id="html_339c03d6d31f4f22a84009d32ddb8672" style="width: 100.0%; height: 100.0%;">Telfs (DE) — pop 15,920</div>`)[0];
+                popup_ec99f8aaccb95d641be1964cbfc80894.setContent(html_339c03d6d31f4f22a84009d32ddb8672);
+            
+        
+
+        circle_marker_0fd1a7ba0190cbc99ec10f1286592d4b.bindPopup(popup_ec99f8aaccb95d641be1964cbfc80894)
+        ;
+
+        
+    
+    
+            var circle_marker_c248ee3906c89687e6c1bdb94a5f338f = L.circleMarker(
+                [46.71503, 11.65598],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.815672225901619, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_e755415588ecdad9b8d8289bb339dfce = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_502790718f24810ff2c131f29ebb73b2 = $(`<div id="html_502790718f24810ff2c131f29ebb73b2" style="width: 100.0%; height: 100.0%;">Brixen (IT) — pop 15,868</div>`)[0];
+                popup_e755415588ecdad9b8d8289bb339dfce.setContent(html_502790718f24810ff2c131f29ebb73b2);
+            
+        
+
+        circle_marker_c248ee3906c89687e6c1bdb94a5f338f.bindPopup(popup_e755415588ecdad9b8d8289bb339dfce)
+        ;
+
+        
+    
+    
+            var circle_marker_5e61cba04767f5cfd9795a3a36f6caa3 = L.circleMarker(
+                [45.4105, 12.36649],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.804458426154494, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_b65b0c5982a38a6739af573a32f249e1 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_a811f527434e27471b56d95021d15ac9 = $(`<div id="html_a811f527434e27471b56d95021d15ac9" style="width: 100.0%; height: 100.0%;">Lido (IT) — pop 15,719</div>`)[0];
+                popup_b65b0c5982a38a6739af573a32f249e1.setContent(html_a811f527434e27471b56d95021d15ac9);
+            
+        
+
+        circle_marker_5e61cba04767f5cfd9795a3a36f6caa3.bindPopup(popup_b65b0c5982a38a6739af573a32f249e1)
+        ;
+
+        
+    
+    
+            var circle_marker_99b6ff31ddf64b2b5d9a6a515cb1b1c3 = L.circleMarker(
+                [47.57143, 10.70171],
+                {"bubblingMouseEvents": true, "color": "blue", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "blue", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.796104521644891, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_c7aa2ff7782cf6a38280ba13fd75de8d = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_75c76375bc8136e526428095e97c2cac = $(`<div id="html_75c76375bc8136e526428095e97c2cac" style="width: 100.0%; height: 100.0%;">Füssen (DE) — pop 15,608</div>`)[0];
+                popup_c7aa2ff7782cf6a38280ba13fd75de8d.setContent(html_75c76375bc8136e526428095e97c2cac);
+            
+        
+
+        circle_marker_99b6ff31ddf64b2b5d9a6a515cb1b1c3.bindPopup(popup_c7aa2ff7782cf6a38280ba13fd75de8d)
+        ;
+
+        
+    
+    
+            var circle_marker_b1b01ec391fbb7859faa6168b7b7f298 = L.circleMarker(
+                [45.71289, 12.25697],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.770290204106208, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_327ea78932dbaaf7f8a549e4619b3718 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_e7ea57d8c8ce0e153e8165887d370841 = $(`<div id="html_e7ea57d8c8ce0e153e8165887d370841" style="width: 100.0%; height: 100.0%;">Lancenigo-Villorba (IT) — pop 15,265</div>`)[0];
+                popup_327ea78932dbaaf7f8a549e4619b3718.setContent(html_e7ea57d8c8ce0e153e8165887d370841);
+            
+        
+
+        circle_marker_b1b01ec391fbb7859faa6168b7b7f298.bindPopup(popup_327ea78932dbaaf7f8a549e4619b3718)
+        ;
+
+        
+    
+    
+            var circle_marker_ddebd2e558f642194d164996b510f133 = L.circleMarker(
+                [47.30707, 11.06817],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.767580829670661, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_797229a4e7ee2b944516cf51013a4f53 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_506fef6a374290423c9570ba589b54e2 = $(`<div id="html_506fef6a374290423c9570ba589b54e2" style="width: 100.0%; height: 100.0%;">Telfs (AT) — pop 15,229</div>`)[0];
+                popup_797229a4e7ee2b944516cf51013a4f53.setContent(html_506fef6a374290423c9570ba589b54e2);
+            
+        
+
+        circle_marker_ddebd2e558f642194d164996b510f133.bindPopup(popup_797229a4e7ee2b944516cf51013a4f53)
+        ;
+
+        
+    
+    
+            var circle_marker_94206b6bf4c01133c6aec0c5f25a05ed = L.circleMarker(
+                [45.7327961, 11.7984223],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.759904268769944, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_d6138cfb51037fd32ebcbc00539fa469 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_8a1d0f397fd2e0511dc57d929ed1e11d = $(`<div id="html_8a1d0f397fd2e0511dc57d929ed1e11d" style="width: 100.0%; height: 100.0%;">Cassola (IT) — pop 15,127</div>`)[0];
+                popup_d6138cfb51037fd32ebcbc00539fa469.setContent(html_8a1d0f397fd2e0511dc57d929ed1e11d);
+            
+        
+
+        circle_marker_94206b6bf4c01133c6aec0c5f25a05ed.bindPopup(popup_d6138cfb51037fd32ebcbc00539fa469)
+        ;
+
+        
+    
+    
+            var circle_marker_55884697a8e889a155b6e5171aad8c6d = L.circleMarker(
+                [45.9145042, 12.8565956],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.75621650912156, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_2ad7e67a7e9f63e5dd2c8f6fd2660013 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_67f9196b603bdf69b58a34f4d93bb431 = $(`<div id="html_67f9196b603bdf69b58a34f4d93bb431" style="width: 100.0%; height: 100.0%;">San Vito al Tagliamento / San Vît dal Tiliment (IT) — pop 15,078</div>`)[0];
+                popup_2ad7e67a7e9f63e5dd2c8f6fd2660013.setContent(html_67f9196b603bdf69b58a34f4d93bb431);
+            
+        
+
+        circle_marker_55884697a8e889a155b6e5171aad8c6d.bindPopup(popup_2ad7e67a7e9f63e5dd2c8f6fd2660013)
+        ;
+
+        
+    
+    
+            var circle_marker_773da456b841ac4b731ae3e6f8bc5768 = L.circleMarker(
+                [46.422819, 11.3347713],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.7555391655126735, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_470e7ca78e09c606eea2d9397bd1bdfe = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_2da952c43540fef84c6dbb7199002837 = $(`<div id="html_2da952c43540fef84c6dbb7199002837" style="width: 100.0%; height: 100.0%;">Laives - Leifers (IT) — pop 15,069</div>`)[0];
+                popup_470e7ca78e09c606eea2d9397bd1bdfe.setContent(html_2da952c43540fef84c6dbb7199002837);
+            
+        
+
+        circle_marker_773da456b841ac4b731ae3e6f8bc5768.bindPopup(popup_470e7ca78e09c606eea2d9397bd1bdfe)
+        ;
+
+        
+    
+    
+            var circle_marker_ee9abed406478be7b1ed64900253868b = L.circleMarker(
+                [46.1273936, 13.2140999],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.749443073032693, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_f7765fe54df40f14a5391329bd5bd61e = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_50cc5ec28dbfe76d0b85b8989d644b78 = $(`<div id="html_50cc5ec28dbfe76d0b85b8989d644b78" style="width: 100.0%; height: 100.0%;">Tavagnacco (IT) — pop 14,988</div>`)[0];
+                popup_f7765fe54df40f14a5391329bd5bd61e.setContent(html_50cc5ec28dbfe76d0b85b8989d644b78);
+            
+        
+
+        circle_marker_ee9abed406478be7b1ed64900253868b.bindPopup(popup_f7765fe54df40f14a5391329bd5bd61e)
+        ;
+
+        
+    
+    
+            var circle_marker_29e3e8771294a497cb4cb7782cd8d84a = L.circleMarker(
+                [45.660296, 11.407493],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.7466584381961585, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_714845a1f3f109acb78f9d062fc5ac89 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_856dc279d5a130937d8d5d76e1661808 = $(`<div id="html_856dc279d5a130937d8d5d76e1661808" style="width: 100.0%; height: 100.0%;">Malo (IT) — pop 14,951</div>`)[0];
+                popup_714845a1f3f109acb78f9d062fc5ac89.setContent(html_856dc279d5a130937d8d5d76e1661808);
+            
+        
+
+        circle_marker_29e3e8771294a497cb4cb7782cd8d84a.bindPopup(popup_714845a1f3f109acb78f9d062fc5ac89)
+        ;
+
+        
+    
+    
+            var circle_marker_6fac032861bbc18783089db2932cb328 = L.circleMarker(
+                [45.8915, 10.18879],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.745228490577398, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_ae168abec9434967f1daabaf3e59b325 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_3ebafbd3cbe24eaf8c339242d53c5445 = $(`<div id="html_3ebafbd3cbe24eaf8c339242d53c5445" style="width: 100.0%; height: 100.0%;">Darfo Boario Terme (IT) — pop 14,932</div>`)[0];
+                popup_ae168abec9434967f1daabaf3e59b325.setContent(html_3ebafbd3cbe24eaf8c339242d53c5445);
+            
+        
+
+        circle_marker_6fac032861bbc18783089db2932cb328.bindPopup(popup_ae168abec9434967f1daabaf3e59b325)
+        ;
+
+        
+    
+    
+            var circle_marker_ffcf3b32f6926a2c2f08004ab0550a3d = L.circleMarker(
+                [45.4234356, 12.0743252],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.7419170329339515, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_7ff91f8c498ecd83d8d4bceea2d18312 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_24ad28effb8b384c36d8d7de92812643 = $(`<div id="html_24ad28effb8b384c36d8d7de92812643" style="width: 100.0%; height: 100.0%;">Dolo (IT) — pop 14,888</div>`)[0];
+                popup_7ff91f8c498ecd83d8d4bceea2d18312.setContent(html_24ad28effb8b384c36d8d7de92812643);
+            
+        
+
+        circle_marker_ffcf3b32f6926a2c2f08004ab0550a3d.bindPopup(popup_7ff91f8c498ecd83d8d4bceea2d18312)
+        ;
+
+        
+    
+    
+            var circle_marker_efb58b9eb871a14c42846744d08642ec = L.circleMarker(
+                [45.502855, 11.9074958],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.7253597447167195, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_045a4d1b19e3e9e219148b5a70aa22ee = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_0dab7d42915d509d9c2eac1c8dfd00f5 = $(`<div id="html_0dab7d42915d509d9c2eac1c8dfd00f5" style="width: 100.0%; height: 100.0%;">Campodarsego (IT) — pop 14,668</div>`)[0];
+                popup_045a4d1b19e3e9e219148b5a70aa22ee.setContent(html_0dab7d42915d509d9c2eac1c8dfd00f5);
+            
+        
+
+        circle_marker_efb58b9eb871a14c42846744d08642ec.bindPopup(popup_045a4d1b19e3e9e219148b5a70aa22ee)
+        ;
+
+        
+    
+    
+            var circle_marker_7a61590d36672973bb4bf685d76eb8b0 = L.circleMarker(
+                [45.6279075, 12.3747797],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.719489433439701, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_0647797bc6649dbfe6ead9b20c235622 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_6b7ece234f1a809c8df8cb9939b9ad18 = $(`<div id="html_6b7ece234f1a809c8df8cb9939b9ad18" style="width: 100.0%; height: 100.0%;">Roncade (IT) — pop 14,590</div>`)[0];
+                popup_0647797bc6649dbfe6ead9b20c235622.setContent(html_6b7ece234f1a809c8df8cb9939b9ad18);
+            
+        
+
+        circle_marker_7a61590d36672973bb4bf685d76eb8b0.bindPopup(popup_0647797bc6649dbfe6ead9b20c235622)
+        ;
+
+        
+    
+    
+            var circle_marker_1357d62a278e93b9900c2060402a0890 = L.circleMarker(
+                [45.7244163, 11.7626859],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.712640736949846, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_d88b98cd953cf92fdbbbc90363a6c2c7 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_f19e9e9f5cd33234b5da060553e73e95 = $(`<div id="html_f19e9e9f5cd33234b5da060553e73e95" style="width: 100.0%; height: 100.0%;">Rosà (IT) — pop 14,499</div>`)[0];
+                popup_d88b98cd953cf92fdbbbc90363a6c2c7.setContent(html_f19e9e9f5cd33234b5da060553e73e95);
+            
+        
+
+        circle_marker_1357d62a278e93b9900c2060402a0890.bindPopup(popup_d88b98cd953cf92fdbbbc90363a6c2c7)
+        ;
+
+        
+    
+    
+            var circle_marker_80b15ad76bf99f74a587feee06190b9e = L.circleMarker(
+                [45.7962374, 11.7583907],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.711060268529111, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_17e95475a9fb1c7b8bed50580cd7cff0 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_eba38bf03165f9b6b4ea4e70728ee44a = $(`<div id="html_eba38bf03165f9b6b4ea4e70728ee44a" style="width: 100.0%; height: 100.0%;">Romano d'Ezzelino (IT) — pop 14,478</div>`)[0];
+                popup_17e95475a9fb1c7b8bed50580cd7cff0.setContent(html_eba38bf03165f9b6b4ea4e70728ee44a);
+            
+        
+
+        circle_marker_80b15ad76bf99f74a587feee06190b9e.bindPopup(popup_17e95475a9fb1c7b8bed50580cd7cff0)
+        ;
+
+        
+    
+    
+            var circle_marker_8c3143032868a5e16ddb0ab213c955c2 = L.circleMarker(
+                [47.55996, 10.21394],
+                {"bubblingMouseEvents": true, "color": "blue", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "blue", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.707523029682702, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_0ee86d9094f4f59f3d582f4319f85e92 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_28b29c98e3ac80d5f6b2e474593281bb = $(`<div id="html_28b29c98e3ac80d5f6b2e474593281bb" style="width: 100.0%; height: 100.0%;">Immenstadt im Allgäu (DE) — pop 14,431</div>`)[0];
+                popup_0ee86d9094f4f59f3d582f4319f85e92.setContent(html_28b29c98e3ac80d5f6b2e474593281bb);
+            
+        
+
+        circle_marker_8c3143032868a5e16ddb0ab213c955c2.bindPopup(popup_0ee86d9094f4f59f3d582f4319f85e92)
+        ;
+
+        
+    
+    
+            var circle_marker_7ae679f2dbe6d5d35675ed80eb9ce8a0 = L.circleMarker(
+                [45.9611171, 12.9789516],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.706770425672828, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_6fa5adf068ea1e94b1530b8a674470a2 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_31e6c64eaa8502ecf420b813b901b89b = $(`<div id="html_31e6c64eaa8502ecf420b813b901b89b" style="width: 100.0%; height: 100.0%;">Codroipo / Codroip (IT) — pop 14,421</div>`)[0];
+                popup_6fa5adf068ea1e94b1530b8a674470a2.setContent(html_31e6c64eaa8502ecf420b813b901b89b);
+            
+        
+
+        circle_marker_7ae679f2dbe6d5d35675ed80eb9ce8a0.bindPopup(popup_6fa5adf068ea1e94b1530b8a674470a2)
+        ;
+
+        
+    
+    
+            var circle_marker_386d05a5ae0f89199f89823ba2fd7726 = L.circleMarker(
+                [47.2816648, 11.5075337],
+                {"bubblingMouseEvents": true, "color": "blue", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "blue", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.706544644469866, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_e7e9e7a4aa07ce13a186677a3780164a = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_6bbee35e894eefd932b26474b753c58e = $(`<div id="html_6bbee35e894eefd932b26474b753c58e" style="width: 100.0%; height: 100.0%;">Hall in Tirol (DE) — pop 14,418</div>`)[0];
+                popup_e7e9e7a4aa07ce13a186677a3780164a.setContent(html_6bbee35e894eefd932b26474b753c58e);
+            
+        
+
+        circle_marker_386d05a5ae0f89199f89823ba2fd7726.bindPopup(popup_e7e9e7a4aa07ce13a186677a3780164a)
+        ;
+
+        
+    
+    
+            var circle_marker_cdc774cba82a7c7013305dd755a32eec = L.circleMarker(
+                [45.7453924, 11.6568938],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.674257932446264, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_2bdae3a87d981733c4e16a42c9b536be = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_e76ba55d41bdcd22b0ac92dcdf10b395 = $(`<div id="html_e76ba55d41bdcd22b0ac92dcdf10b395" style="width: 100.0%; height: 100.0%;">Marostica (IT) — pop 13,989</div>`)[0];
+                popup_2bdae3a87d981733c4e16a42c9b536be.setContent(html_e76ba55d41bdcd22b0ac92dcdf10b395);
+            
+        
+
+        circle_marker_cdc774cba82a7c7013305dd755a32eec.bindPopup(popup_2bdae3a87d981733c4e16a42c9b536be)
+        ;
+
+        
+    
+    
+            var circle_marker_3b05cf80897da63b04a5f027821fe903 = L.circleMarker(
+                [45.6355174, 11.5485978],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.670494912396893, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_5ffcbe8fdec24646771e1ae04c0590ba = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_7699cedede52db980943579b246693bb = $(`<div id="html_7699cedede52db980943579b246693bb" style="width: 100.0%; height: 100.0%;">Dueville (IT) — pop 13,939</div>`)[0];
+                popup_5ffcbe8fdec24646771e1ae04c0590ba.setContent(html_7699cedede52db980943579b246693bb);
+            
+        
+
+        circle_marker_3b05cf80897da63b04a5f027821fe903.bindPopup(popup_5ffcbe8fdec24646771e1ae04c0590ba)
+        ;
+
+        
+    
+    
+            var circle_marker_bb3fe7ce8587d5d1e489df5252b2621e = L.circleMarker(
+                [47.48906, 12.06174],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.660861581070504, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_bc89134b9b6d1c879034467cc949ba90 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_a00992869d572efd3603089158ac84de = $(`<div id="html_a00992869d572efd3603089158ac84de" style="width: 100.0%; height: 100.0%;">Wörgl (AT) — pop 13,811</div>`)[0];
+                popup_bc89134b9b6d1c879034467cc949ba90.setContent(html_a00992869d572efd3603089158ac84de);
+            
+        
+
+        circle_marker_bb3fe7ce8587d5d1e489df5252b2621e.bindPopup(popup_bc89134b9b6d1c879034467cc949ba90)
+        ;
+
+        
+    
+    
+            var circle_marker_f0dd5b67c2d5c399b9c9cd03360e5a11 = L.circleMarker(
+                [47.4872718, 12.0637633],
+                {"bubblingMouseEvents": true, "color": "blue", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "blue", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.660861581070504, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_64cfab5371ed55e56f55bd856fbc136b = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_dadbd0b16ab181293a8e6c667cce9373 = $(`<div id="html_dadbd0b16ab181293a8e6c667cce9373" style="width: 100.0%; height: 100.0%;">Wörgl (DE) — pop 13,811</div>`)[0];
+                popup_64cfab5371ed55e56f55bd856fbc136b.setContent(html_dadbd0b16ab181293a8e6c667cce9373);
+            
+        
+
+        circle_marker_f0dd5b67c2d5c399b9c9cd03360e5a11.bindPopup(popup_64cfab5371ed55e56f55bd856fbc136b)
+        ;
+
+        
+    
+    
+            var circle_marker_971b6e7651d311fcc7456a4e4e50ba35 = L.circleMarker(
+                [47.35169, 11.71014],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.654614967788548, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_845a45ad95050124d2738f6be5412151 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_1754f4651b120802ab5560a42f5d7c25 = $(`<div id="html_1754f4651b120802ab5560a42f5d7c25" style="width: 100.0%; height: 100.0%;">Schwaz (AT) — pop 13,728</div>`)[0];
+                popup_845a45ad95050124d2738f6be5412151.setContent(html_1754f4651b120802ab5560a42f5d7c25);
+            
+        
+
+        circle_marker_971b6e7651d311fcc7456a4e4e50ba35.bindPopup(popup_845a45ad95050124d2738f6be5412151)
+        ;
+
+        
+    
+    
+            var circle_marker_c402c6324a822dab0d121ee254092a95 = L.circleMarker(
+                [46.7963194, 11.9355121],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.646336323679932, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_f378dc597f37a5e070aff34ee4572f48 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_4f0408078857882093fc56d05f2fa40a = $(`<div id="html_4f0408078857882093fc56d05f2fa40a" style="width: 100.0%; height: 100.0%;">Bruneck - Brunico (IT) — pop 13,618</div>`)[0];
+                popup_f378dc597f37a5e070aff34ee4572f48.setContent(html_4f0408078857882093fc56d05f2fa40a);
+            
+        
+
+        circle_marker_c402c6324a822dab0d121ee254092a95.bindPopup(popup_f378dc597f37a5e070aff34ee4572f48)
+        ;
+
+        
+    
+    
+            var circle_marker_308765f926caf60e6bd0f7bba58096a6 = L.circleMarker(
+                [47.15476, 9.82255],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.64001444999699, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_2fcaac399dcab6cb5a5af93b232bced6 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_191bc620c5bce179b7ec659e0f162191 = $(`<div id="html_191bc620c5bce179b7ec659e0f162191" style="width: 100.0%; height: 100.0%;">Bludenz (AT) — pop 13,534</div>`)[0];
+                popup_2fcaac399dcab6cb5a5af93b232bced6.setContent(html_191bc620c5bce179b7ec659e0f162191);
+            
+        
+
+        circle_marker_308765f926caf60e6bd0f7bba58096a6.bindPopup(popup_2fcaac399dcab6cb5a5af93b232bced6)
+        ;
+
+        
+    
+    
+            var circle_marker_f853be218256fb4759bf9e8c4ac9614e = L.circleMarker(
+                [47.48306, 9.68306],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.637079294358481, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_29d94706d2e2a0d86972403a82119e50 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_caa27c7851268c84838f028a851c2124 = $(`<div id="html_caa27c7851268c84838f028a851c2124" style="width: 100.0%; height: 100.0%;">Hard (AT) — pop 13,495</div>`)[0];
+                popup_29d94706d2e2a0d86972403a82119e50.setContent(html_caa27c7851268c84838f028a851c2124);
+            
+        
+
+        circle_marker_f853be218256fb4759bf9e8c4ac9614e.bindPopup(popup_29d94706d2e2a0d86972403a82119e50)
+        ;
+
+        
+    
+    
+            var circle_marker_7561d2a55e1c7a951a42c4ee17f2dd35 = L.circleMarker(
+                [45.93056, 12.87083],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.633165753507135, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_bb7e38f7517e2a78d7d357b0fed28889 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_77d708c50381cd505a9ae0dd24f0a4bd = $(`<div id="html_77d708c50381cd505a9ae0dd24f0a4bd" style="width: 100.0%; height: 100.0%;">Rosa (IT) — pop 13,443</div>`)[0];
+                popup_bb7e38f7517e2a78d7d357b0fed28889.setContent(html_77d708c50381cd505a9ae0dd24f0a4bd);
+            
+        
+
+        circle_marker_7561d2a55e1c7a951a42c4ee17f2dd35.bindPopup(popup_bb7e38f7517e2a78d7d357b0fed28889)
+        ;
+
+        
+    
+    
+            var circle_marker_b26a73617a630e957e793c0cd9d0ae51 = L.circleMarker(
+                [47.28333, 11.51667],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.624962369799507, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_e12a68b6b6695252284220133724211d = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_c51c6aac2f2f28698c5a701d805c240d = $(`<div id="html_c51c6aac2f2f28698c5a701d805c240d" style="width: 100.0%; height: 100.0%;">Hall in Tirol (AT) — pop 13,334</div>`)[0];
+                popup_e12a68b6b6695252284220133724211d.setContent(html_c51c6aac2f2f28698c5a701d805c240d);
+            
+        
+
+        circle_marker_b26a73617a630e957e793c0cd9d0ae51.bindPopup(popup_e12a68b6b6695252284220133724211d)
+        ;
+
+        
+    
+    
+            var circle_marker_ddc21c175455053cd5529b314cd8b993 = L.circleMarker(
+                [45.6486593, 11.8569804],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.613146486844482, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_15833aac7683611ee91688f7de0bad70 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_4fc5798bc56f54aeed191783ab36ac93 = $(`<div id="html_4fc5798bc56f54aeed191783ab36ac93" style="width: 100.0%; height: 100.0%;">San Martino di Lupari (IT) — pop 13,177</div>`)[0];
+                popup_15833aac7683611ee91688f7de0bad70.setContent(html_4fc5798bc56f54aeed191783ab36ac93);
+            
+        
+
+        circle_marker_ddc21c175455053cd5529b314cd8b993.bindPopup(popup_15833aac7683611ee91688f7de0bad70)
+        ;
+
+        
+    
+    
+            var circle_marker_991e9307abb63c270dc80504a50b72b5 = L.circleMarker(
+                [47.3449529, 11.7084253],
+                {"bubblingMouseEvents": true, "color": "blue", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "blue", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.604190499126979, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_387f6b7735a5b6cd87198683d764adb5 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_4976539ea939be110236c64549aace30 = $(`<div id="html_4976539ea939be110236c64549aace30" style="width: 100.0%; height: 100.0%;">Schwaz (DE) — pop 13,058</div>`)[0];
+                popup_387f6b7735a5b6cd87198683d764adb5.setContent(html_4976539ea939be110236c64549aace30);
+            
+        
+
+        circle_marker_991e9307abb63c270dc80504a50b72b5.bindPopup(popup_387f6b7735a5b6cd87198683d764adb5)
+        ;
+
+        
+    
+    
+            var circle_marker_3048cbbaefb6d53e8f95d718af956def = L.circleMarker(
+                [45.5445732, 11.2808956],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.601782166295382, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_f476d46ae3c6b81bac5a3024aee0bd69 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_5b3a92c5b6f1aa19a8d61f21a585d06b = $(`<div id="html_5b3a92c5b6f1aa19a8d61f21a585d06b" style="width: 100.0%; height: 100.0%;">Chiampo (IT) — pop 13,026</div>`)[0];
+                popup_f476d46ae3c6b81bac5a3024aee0bd69.setContent(html_5b3a92c5b6f1aa19a8d61f21a585d06b);
+            
+        
+
+        circle_marker_3048cbbaefb6d53e8f95d718af956def.bindPopup(popup_f476d46ae3c6b81bac5a3024aee0bd69)
+        ;
+
+        
+    
+    
+            var circle_marker_baf4324638fc0d59216a4e86e3b46263 = L.circleMarker(
+                [45.5977665, 12.3257335],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.601180083087483, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_9d1bc692363ebc1cbc2c1273f86e5cdb = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_ecd0506009bb57d34114cef7cc5f5707 = $(`<div id="html_ecd0506009bb57d34114cef7cc5f5707" style="width: 100.0%; height: 100.0%;">Casale sul Sile (IT) — pop 13,018</div>`)[0];
+                popup_9d1bc692363ebc1cbc2c1273f86e5cdb.setContent(html_ecd0506009bb57d34114cef7cc5f5707);
+            
+        
+
+        circle_marker_baf4324638fc0d59216a4e86e3b46263.bindPopup(popup_9d1bc692363ebc1cbc2c1273f86e5cdb)
+        ;
+
+        
+    
+    
+            var circle_marker_a9bc8ac9ffe828a0a3f21aef78d25064 = L.circleMarker(
+                [45.96301, 12.61642],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.598847010656873, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_e2cac2f276b0f951f561905aa6f4cf20 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_c4d4a1f728f850e9a7f486f0c16039d9 = $(`<div id="html_c4d4a1f728f850e9a7f486f0c16039d9" style="width: 100.0%; height: 100.0%;">Porcia (IT) — pop 12,987</div>`)[0];
+                popup_e2cac2f276b0f951f561905aa6f4cf20.setContent(html_c4d4a1f728f850e9a7f486f0c16039d9);
+            
+        
+
+        circle_marker_a9bc8ac9ffe828a0a3f21aef78d25064.bindPopup(popup_e2cac2f276b0f951f561905aa6f4cf20)
+        ;
+
+        
+    
+    
+            var circle_marker_040af75aa7c756c119e639b9195ed216 = L.circleMarker(
+                [45.7310782, 12.6800084],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.594406646998615, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_371cad314cf705846e04ec6c1baffb89 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_08f66ffd00bf6a5d554a1f26e182deec = $(`<div id="html_08f66ffd00bf6a5d554a1f26e182deec" style="width: 100.0%; height: 100.0%;">San Stino di Livenza (IT) — pop 12,928</div>`)[0];
+                popup_371cad314cf705846e04ec6c1baffb89.setContent(html_08f66ffd00bf6a5d554a1f26e182deec);
+            
+        
+
+        circle_marker_040af75aa7c756c119e639b9195ed216.bindPopup(popup_371cad314cf705846e04ec6c1baffb89)
+        ;
+
+        
+    
+    
+            var circle_marker_0402b73ca178e7a19721eb11bced45d6 = L.circleMarker(
+                [46.8, 13.5],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.590794147751219, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_1d3b72051b97ed3312355f5e99e9979a = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_1965e6009b4bd733a46fab9969e8c9d8 = $(`<div id="html_1965e6009b4bd733a46fab9969e8c9d8" style="width: 100.0%; height: 100.0%;">Spittal an der Drau (AT) — pop 12,880</div>`)[0];
+                popup_1d3b72051b97ed3312355f5e99e9979a.setContent(html_1965e6009b4bd733a46fab9969e8c9d8);
+            
+        
+
+        circle_marker_0402b73ca178e7a19721eb11bced45d6.bindPopup(popup_1d3b72051b97ed3312355f5e99e9979a)
+        ;
+
+        
+    
+    
+            var circle_marker_4cb013c820a6050a777d4d080825a994 = L.circleMarker(
+                [45.8814199, 12.7143145],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.590794147751219, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_234604567ca08187ffbc7818e0acd504 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_5acbd4ec598cb1ae6c7e4ff44e430717 = $(`<div id="html_5acbd4ec598cb1ae6c7e4ff44e430717" style="width: 100.0%; height: 100.0%;">Azzano Decimo / Daçan di Pordenon (IT) — pop 12,880</div>`)[0];
+                popup_234604567ca08187ffbc7818e0acd504.setContent(html_5acbd4ec598cb1ae6c7e4ff44e430717);
+            
+        
+
+        circle_marker_4cb013c820a6050a777d4d080825a994.bindPopup(popup_234604567ca08187ffbc7818e0acd504)
+        ;
+
+        
+    
+    
+            var circle_marker_da4ba7ad404b9d45152cb34b883875f7 = L.circleMarker(
+                [45.5918117, 12.0509986],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.587783731711722, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_c1c590ddae8bb35e663e9a788d20aac8 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_b9f3cd7b56716e2fbdf6ba64ed485e0a = $(`<div id="html_b9f3cd7b56716e2fbdf6ba64ed485e0a" style="width: 100.0%; height: 100.0%;">Trebaseleghe (IT) — pop 12,840</div>`)[0];
+                popup_c1c590ddae8bb35e663e9a788d20aac8.setContent(html_b9f3cd7b56716e2fbdf6ba64ed485e0a);
+            
+        
+
+        circle_marker_da4ba7ad404b9d45152cb34b883875f7.bindPopup(popup_c1c590ddae8bb35e663e9a788d20aac8)
+        ;
+
+        
+    
+    
+            var circle_marker_938bb490ecac45d8f3f1623e4ca83443 = L.circleMarker(
+                [45.6861778, 11.7041837],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.5868053464988865, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_d4a385cd06e4a5bfa302e67cee4eebd2 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_3a0a26381d46c6c66bc5916366791a8e = $(`<div id="html_3a0a26381d46c6c66bc5916366791a8e" style="width: 100.0%; height: 100.0%;">Tezze sul Brenta (IT) — pop 12,827</div>`)[0];
+                popup_d4a385cd06e4a5bfa302e67cee4eebd2.setContent(html_3a0a26381d46c6c66bc5916366791a8e);
+            
+        
+
+        circle_marker_938bb490ecac45d8f3f1623e4ca83443.bindPopup(popup_d4a385cd06e4a5bfa302e67cee4eebd2)
+        ;
+
+        
+    
+    
+            var circle_marker_e4668e353d131ef45c205282c3056d9b = L.circleMarker(
+                [45.96469, 12.97985],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.585601180083088, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_120a9d87f91b57cc6fd17bc6d7892718 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_bd88b380c45205d219f793fbd95060be = $(`<div id="html_bd88b380c45205d219f793fbd95060be" style="width: 100.0%; height: 100.0%;">Codroipo (IT) — pop 12,811</div>`)[0];
+                popup_120a9d87f91b57cc6fd17bc6d7892718.setContent(html_bd88b380c45205d219f793fbd95060be);
+            
+        
+
+        circle_marker_e4668e353d131ef45c205282c3056d9b.bindPopup(popup_120a9d87f91b57cc6fd17bc6d7892718)
+        ;
+
+        
+    
+    
+            var circle_marker_239aa8874cf52f7379bdb07a58a5efe5 = L.circleMarker(
+                [45.521344, 12.1063704],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.583042326449515, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_82fb6a6881788bcc9971495598495dcd = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_c3e7059edc991592a45cff39ca47f773 = $(`<div id="html_c3e7059edc991592a45cff39ca47f773" style="width: 100.0%; height: 100.0%;">Salzano (IT) — pop 12,777</div>`)[0];
+                popup_82fb6a6881788bcc9971495598495dcd.setContent(html_c3e7059edc991592a45cff39ca47f773);
+            
+        
+
+        circle_marker_239aa8874cf52f7379bdb07a58a5efe5.bindPopup(popup_82fb6a6881788bcc9971495598495dcd)
+        ;
+
+        
+    
+    
+            var circle_marker_b4df6ad2d7a9eea6ba9b1a9877db975f = L.circleMarker(
+                [45.6848725, 12.3773466],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.575441025949786, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_86586714f35350cde996a82a050d99dd = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_8bf308c9c9a534d0b170188868f55e00 = $(`<div id="html_8bf308c9c9a534d0b170188868f55e00" style="width: 100.0%; height: 100.0%;">San Biagio di Callalta (IT) — pop 12,676</div>`)[0];
+                popup_86586714f35350cde996a82a050d99dd.setContent(html_8bf308c9c9a534d0b170188868f55e00);
+            
+        
+
+        circle_marker_b4df6ad2d7a9eea6ba9b1a9877db975f.bindPopup(popup_86586714f35350cde996a82a050d99dd)
+        ;
+
+        
+    
+    
+            var circle_marker_a9e38aa5338decde65e62c946f4c76f3 = L.circleMarker(
+                [45.9168, 12.85945],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.5696459750737555, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_8f8c569bebfc346bb6eff0589078b34b = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_f390efa3e6b25cf015b0edc8b057815d = $(`<div id="html_f390efa3e6b25cf015b0edc8b057815d" style="width: 100.0%; height: 100.0%;">San Vito al Tagliamento (IT) — pop 12,599</div>`)[0];
+                popup_8f8c569bebfc346bb6eff0589078b34b.setContent(html_f390efa3e6b25cf015b0edc8b057815d);
+            
+        
+
+        circle_marker_a9e38aa5338decde65e62c946f4c76f3.bindPopup(popup_8f8c569bebfc346bb6eff0589078b34b)
+        ;
+
+        
+    
+    
+            var circle_marker_e69cddfa831c187c91dae382c35c556e = L.circleMarker(
+                [45.8228339, 13.336382],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.556249623697995, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_9460ebc7d44ba603ce1744afbdb8502c = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_bc09b5170d9c42d3a82217d5cb9bab8e = $(`<div id="html_bc09b5170d9c42d3a82217d5cb9bab8e" style="width: 100.0%; height: 100.0%;">Cervignano del Friuli / Çarvignan (IT) — pop 12,421</div>`)[0];
+                popup_9460ebc7d44ba603ce1744afbdb8502c.setContent(html_bc09b5170d9c42d3a82217d5cb9bab8e);
+            
+        
+
+        circle_marker_e69cddfa831c187c91dae382c35c556e.bindPopup(popup_9460ebc7d44ba603ce1744afbdb8502c)
+        ;
+
+        
+    
+    
+            var circle_marker_e39f96387a019639dd157a48aab2a5cc = L.circleMarker(
+                [45.5762676, 12.6729111],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.55436811367331, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_d459e662421ad9850a81d9e9bba106a1 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_b3aa715d93fa85c8c37c8c29ec4baec8 = $(`<div id="html_b3aa715d93fa85c8c37c8c29ec4baec8" style="width: 100.0%; height: 100.0%;">Eraclea (IT) — pop 12,396</div>`)[0];
+                popup_d459e662421ad9850a81d9e9bba106a1.setContent(html_b3aa715d93fa85c8c37c8c29ec4baec8);
+            
+        
+
+        circle_marker_e39f96387a019639dd157a48aab2a5cc.bindPopup(popup_d459e662421ad9850a81d9e9bba106a1)
+        ;
+
+        
+    
+    
+            var circle_marker_d87dacc196158afdc974e47f5d02d512 = L.circleMarker(
+                [47.6778816, 11.2011903],
+                {"bubblingMouseEvents": true, "color": "blue", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "blue", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.554292853272322, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_641d92211f905ab36ba05001504ac33d = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_01a8588d44c5fe95e83e85a377282302 = $(`<div id="html_01a8588d44c5fe95e83e85a377282302" style="width: 100.0%; height: 100.0%;">Murnau am Staffelsee (DE) — pop 12,395</div>`)[0];
+                popup_641d92211f905ab36ba05001504ac33d.setContent(html_01a8588d44c5fe95e83e85a377282302);
+            
+        
+
+        circle_marker_d87dacc196158afdc974e47f5d02d512.bindPopup(popup_641d92211f905ab36ba05001504ac33d)
+        ;
+
+        
+    
+    
+            var circle_marker_f32943c9cc8a9430c3a05ea863a99d29 = L.circleMarker(
+                [45.90937, 12.6642],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.548648323198266, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_cd04b1424e881f2c0052d2044419d425 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_b86f4de9e2382f2099a52540e458f5b4 = $(`<div id="html_b86f4de9e2382f2099a52540e458f5b4" style="width: 100.0%; height: 100.0%;">Azzano Decimo (IT) — pop 12,320</div>`)[0];
+                popup_cd04b1424e881f2c0052d2044419d425.setContent(html_b86f4de9e2382f2099a52540e458f5b4);
+            
+        
+
+        circle_marker_f32943c9cc8a9430c3a05ea863a99d29.bindPopup(popup_cd04b1424e881f2c0052d2044419d425)
+        ;
+
+        
+    
+    
+            var circle_marker_039005d60faa9558290d5e62330e8c25 = L.circleMarker(
+                [46.6160189, 11.1448586],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.546089469564694, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_17101b1023e26e10d533c7eb00d0e2d8 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_65d87fe572f8a222afcc75501d68fc22 = $(`<div id="html_65d87fe572f8a222afcc75501d68fc22" style="width: 100.0%; height: 100.0%;">Lana (IT) — pop 12,286</div>`)[0];
+                popup_17101b1023e26e10d533c7eb00d0e2d8.setContent(html_65d87fe572f8a222afcc75501d68fc22);
+            
+        
+
+        circle_marker_039005d60faa9558290d5e62330e8c25.bindPopup(popup_17101b1023e26e10d533c7eb00d0e2d8)
+        ;
+
+        
+    
+    
+            var circle_marker_5787c7d6b01993a84c861ed307d1a112 = L.circleMarker(
+                [46.79942, 11.93429],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.545788427960744, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_334ef933a2c911a679ac45c0d0f604eb = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_f15dfc93fce216cdfbadcf819cce6ac9 = $(`<div id="html_f15dfc93fce216cdfbadcf819cce6ac9" style="width: 100.0%; height: 100.0%;">Bruneck (IT) — pop 12,282</div>`)[0];
+                popup_334ef933a2c911a679ac45c0d0f604eb.setContent(html_f15dfc93fce216cdfbadcf819cce6ac9);
+            
+        
+
+        circle_marker_5787c7d6b01993a84c861ed307d1a112.bindPopup(popup_334ef933a2c911a679ac45c0d0f604eb)
+        ;
+
+        
+    
+    
+            var circle_marker_82ef94845bcd003787567231b3257204 = L.circleMarker(
+                [45.4560955, 12.0301727],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.54563790715877, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_0675528887340f25ec609c23aa7d1e55 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_45910f663bc5393e0f328270644f57ad = $(`<div id="html_45910f663bc5393e0f328270644f57ad" style="width: 100.0%; height: 100.0%;">Pianiga (IT) — pop 12,280</div>`)[0];
+                popup_0675528887340f25ec609c23aa7d1e55.setContent(html_45910f663bc5393e0f328270644f57ad);
+            
+        
+
+        circle_marker_82ef94845bcd003787567231b3257204.bindPopup(popup_0675528887340f25ec609c23aa7d1e55)
+        ;
+
+        
+    
+    
+            var circle_marker_5b06808545f99aa00da5bbddc8042810 = L.circleMarker(
+                [45.82082, 13.33929],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.545261605153832, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_995bb6c74919e395359facc1f24ee79d = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_8c6981fe97e057a047f0d47791b33b26 = $(`<div id="html_8c6981fe97e057a047f0d47791b33b26" style="width: 100.0%; height: 100.0%;">Cervignano del Friuli (IT) — pop 12,275</div>`)[0];
+                popup_995bb6c74919e395359facc1f24ee79d.setContent(html_8c6981fe97e057a047f0d47791b33b26);
+            
+        
+
+        circle_marker_5b06808545f99aa00da5bbddc8042810.bindPopup(popup_995bb6c74919e395359facc1f24ee79d)
+        ;
+
+        
+    
+    
+            var circle_marker_8493358cc00893c2b46cb32d75da65be = L.circleMarker(
+                [45.9733967, 12.5691228],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.539240773074839, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_3081aec02b64d5ef34324cb08f8e2d85 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_bd3d7225431bdc48fb506a5fb96e2ec0 = $(`<div id="html_bd3d7225431bdc48fb506a5fb96e2ec0" style="width: 100.0%; height: 100.0%;">Fontanafredda / Fontanefrede (IT) — pop 12,195</div>`)[0];
+                popup_3081aec02b64d5ef34324cb08f8e2d85.setContent(html_bd3d7225431bdc48fb506a5fb96e2ec0);
+            
+        
+
+        circle_marker_8493358cc00893c2b46cb32d75da65be.bindPopup(popup_3081aec02b64d5ef34324cb08f8e2d85)
+        ;
+
+        
+    
+    
+            var circle_marker_03d1880a9f72c1e1b6c8291a6a357b33 = L.circleMarker(
+                [45.7803913, 12.2593456],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.537810825456078, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_a62231d829d1548381681ef91b31aefc = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_a07b2bbc0f7895fa9daf9e2eca2a4ee2 = $(`<div id="html_a07b2bbc0f7895fa9daf9e2eca2a4ee2" style="width: 100.0%; height: 100.0%;">Spresiano (IT) — pop 12,176</div>`)[0];
+                popup_a62231d829d1548381681ef91b31aefc.setContent(html_a07b2bbc0f7895fa9daf9e2eca2a4ee2);
+            
+        
+
+        circle_marker_03d1880a9f72c1e1b6c8291a6a357b33.bindPopup(popup_a62231d829d1548381681ef91b31aefc)
+        ;
+
+        
+    
+    
+            var circle_marker_3a93f71a9f0f43486ca18111115322b4 = L.circleMarker(
+                [45.57176, 11.9319294],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.534649888614607, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_9b466b8d044bd8a0db9eebab6cb9d078 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_873aaab373ef5ad8018e01e6351d0e9e = $(`<div id="html_873aaab373ef5ad8018e01e6351d0e9e" style="width: 100.0%; height: 100.0%;">Camposampiero (IT) — pop 12,134</div>`)[0];
+                popup_9b466b8d044bd8a0db9eebab6cb9d078.setContent(html_873aaab373ef5ad8018e01e6351d0e9e);
+            
+        
+
+        circle_marker_3a93f71a9f0f43486ca18111115322b4.bindPopup(popup_9b466b8d044bd8a0db9eebab6cb9d078)
+        ;
+
+        
+    
+    
+            var circle_marker_c52fc546ce7dc1227f058a17842fed7c = L.circleMarker(
+                [45.8997613, 12.1730811],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.532542597386959, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_213c7a96961e8f675257d9ecce06963d = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_cc99b6d71ac72f68cc29033d05ad9358 = $(`<div id="html_cc99b6d71ac72f68cc29033d05ad9358" style="width: 100.0%; height: 100.0%;">Pieve di Soligo (IT) — pop 12,106</div>`)[0];
+                popup_213c7a96961e8f675257d9ecce06963d.setContent(html_cc99b6d71ac72f68cc29033d05ad9358);
+            
+        
+
+        circle_marker_c52fc546ce7dc1227f058a17842fed7c.bindPopup(popup_213c7a96961e8f675257d9ecce06963d)
+        ;
+
+        
+    
+    
+            var circle_marker_51bbce2f77bdc55796bf72e5f6a94ff0 = L.circleMarker(
+                [45.6111057, 11.3434053],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.530585826961286, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_1df0b43c59f32e11d6c2c000f95a732a = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_ff3fb4e720cdbb3835c9088fc90b5cc9 = $(`<div id="html_ff3fb4e720cdbb3835c9088fc90b5cc9" style="width: 100.0%; height: 100.0%;">Cornedo Vicentino (IT) — pop 12,080</div>`)[0];
+                popup_1df0b43c59f32e11d6c2c000f95a732a.setContent(html_ff3fb4e720cdbb3835c9088fc90b5cc9);
+            
+        
+
+        circle_marker_51bbce2f77bdc55796bf72e5f6a94ff0.bindPopup(popup_1df0b43c59f32e11d6c2c000f95a732a)
+        ;
+
+        
+    
+    
+            var circle_marker_2c1e17f9d9fda800c00ac3db6e55c2b7 = L.circleMarker(
+                [46.8298662, 12.7681269],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.530360045758323, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_65c869ce5bb7f6d6c0b27b801d0e12b3 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_76523f282ea3bc736429a4a9f4518c7e = $(`<div id="html_76523f282ea3bc736429a4a9f4518c7e" style="width: 100.0%; height: 100.0%;">Lienz (IT) — pop 12,077</div>`)[0];
+                popup_65c869ce5bb7f6d6c0b27b801d0e12b3.setContent(html_76523f282ea3bc736429a4a9f4518c7e);
+            
+        
+
+        circle_marker_2c1e17f9d9fda800c00ac3db6e55c2b7.bindPopup(popup_65c869ce5bb7f6d6c0b27b801d0e12b3)
+        ;
+
+        
+    
+    
+            var circle_marker_36ea30a7206bebfc62389440cf3f6f23 = L.circleMarker(
+                [45.5084288, 11.4706863],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.528779577337588, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_fd8a76503a161396f05af4cebd8a04f4 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_759f44498d44219a1349bde749aedbd7 = $(`<div id="html_759f44498d44219a1349bde749aedbd7" style="width: 100.0%; height: 100.0%;">Altavilla Vicentina (IT) — pop 12,056</div>`)[0];
+                popup_fd8a76503a161396f05af4cebd8a04f4.setContent(html_759f44498d44219a1349bde749aedbd7);
+            
+        
+
+        circle_marker_36ea30a7206bebfc62389440cf3f6f23.bindPopup(popup_fd8a76503a161396f05af4cebd8a04f4)
+        ;
+
+        
+    
+    
+            var circle_marker_e63596c38990462844dabb2b246bb721 = L.circleMarker(
+                [45.82735, 13.50417],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.517189475585526, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_5bb24b02577f7c71daf0d191aba78e6b = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_d5c7d191ea5cc21d08a334c2ddea99f9 = $(`<div id="html_d5c7d191ea5cc21d08a334c2ddea99f9" style="width: 100.0%; height: 100.0%;">Ronchi dei Legionari (IT) — pop 11,902</div>`)[0];
+                popup_5bb24b02577f7c71daf0d191aba78e6b.setContent(html_d5c7d191ea5cc21d08a334c2ddea99f9);
+            
+        
+
+        circle_marker_e63596c38990462844dabb2b246bb721.bindPopup(popup_5bb24b02577f7c71daf0d191aba78e6b)
+        ;
+
+        
+    
+    
+            var circle_marker_ab432c90c34be21c8e0925fd5850131a = L.circleMarker(
+                [47.27108, 9.64308],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.513652236739118, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_acd99d0302344d8d8feb0bcfd7f71179 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_72a8310f06d06f7490dd64d82604c05c = $(`<div id="html_72a8310f06d06f7490dd64d82604c05c" style="width: 100.0%; height: 100.0%;">Rankweil (AT) — pop 11,855</div>`)[0];
+                popup_acd99d0302344d8d8feb0bcfd7f71179.setContent(html_72a8310f06d06f7490dd64d82604c05c);
+            
+        
+
+        circle_marker_ab432c90c34be21c8e0925fd5850131a.bindPopup(popup_acd99d0302344d8d8feb0bcfd7f71179)
+        ;
+
+        
+    
+    
+            var circle_marker_90d9fe06b5c6f86d977f8ed2c5947dfd = L.circleMarker(
+                [45.8509126, 12.2500126],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.512147028719369, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_9b0204d55797dfea10bebb6e05fd0349 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_7edfc21d99e549ceddd3cb124b8d5966 = $(`<div id="html_7edfc21d99e549ceddd3cb124b8d5966" style="width: 100.0%; height: 100.0%;">Susegana (IT) — pop 11,835</div>`)[0];
+                popup_9b0204d55797dfea10bebb6e05fd0349.setContent(html_7edfc21d99e549ceddd3cb124b8d5966);
+            
+        
+
+        circle_marker_90d9fe06b5c6f86d977f8ed2c5947dfd.bindPopup(popup_9b0204d55797dfea10bebb6e05fd0349)
+        ;
+
+        
+    
+    
+            var circle_marker_8ff0b913f4d991353018a522a73bbfe6 = L.circleMarker(
+                [45.5192662, 11.6171199],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.510190258293696, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_ef35159d406165aeca1b016e1fd9563f = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_13a7d0a057b5ce6fe0f1dc48910c1936 = $(`<div id="html_13a7d0a057b5ce6fe0f1dc48910c1936" style="width: 100.0%; height: 100.0%;">Torri di Quartesolo (IT) — pop 11,809</div>`)[0];
+                popup_ef35159d406165aeca1b016e1fd9563f.setContent(html_13a7d0a057b5ce6fe0f1dc48910c1936);
+            
+        
+
+        circle_marker_8ff0b913f4d991353018a522a73bbfe6.bindPopup(popup_ef35159d406165aeca1b016e1fd9563f)
+        ;
+
+        
+    
+    
+            var circle_marker_3bfd68395a798a863a4f7d511ce5561a = L.circleMarker(
+                [46.1709743, 12.7073987],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.502588957793967, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_2b166fc1e9429ec7bd8349238c6ccf6f = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_8caa6daffc99a72a956b775fb9f638dc = $(`<div id="html_8caa6daffc99a72a956b775fb9f638dc" style="width: 100.0%; height: 100.0%;">Maniago / Manià (IT) — pop 11,708</div>`)[0];
+                popup_2b166fc1e9429ec7bd8349238c6ccf6f.setContent(html_8caa6daffc99a72a956b775fb9f638dc);
+            
+        
+
+        circle_marker_3bfd68395a798a863a4f7d511ce5561a.bindPopup(popup_2b166fc1e9429ec7bd8349238c6ccf6f)
+        ;
+
+        
+    
+    
+            var circle_marker_9fe6fc10dde1a1472b32f6b4b5a80dcb = L.circleMarker(
+                [45.9279427, 12.7321755],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.500255885363357, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_d51f218c103ccb5514da79fa2a6f786f = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_199e0980b542bc18a3926ee709253e65 = $(`<div id="html_199e0980b542bc18a3926ee709253e65" style="width: 100.0%; height: 100.0%;">Fiume Veneto / Vile di Flum (IT) — pop 11,677</div>`)[0];
+                popup_d51f218c103ccb5514da79fa2a6f786f.setContent(html_199e0980b542bc18a3926ee709253e65);
+            
+        
+
+        circle_marker_9fe6fc10dde1a1472b32f6b4b5a80dcb.bindPopup(popup_d51f218c103ccb5514da79fa2a6f786f)
+        ;
+
+        
+    
+    
+            var circle_marker_49d1440e4a92f6d739af3476c2325f7c = L.circleMarker(
+                [45.5979147, 12.8876282],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.49987958335842, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_fe674e73804c5279f94ac7531191fe0d = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_3860bfd2a5b552339371d0ecd643448e = $(`<div id="html_3860bfd2a5b552339371d0ecd643448e" style="width: 100.0%; height: 100.0%;">Caorle (IT) — pop 11,672</div>`)[0];
+                popup_fe674e73804c5279f94ac7531191fe0d.setContent(html_3860bfd2a5b552339371d0ecd643448e);
+            
+        
+
+        circle_marker_49d1440e4a92f6d739af3476c2325f7c.bindPopup(popup_fe674e73804c5279f94ac7531191fe0d)
+        ;
+
+        
+    
+    
+            var circle_marker_cea2f1916c04db8f9e7067dd6dd0cb24 = L.circleMarker(
+                [45.92341, 6.69562],
+                {"bubblingMouseEvents": true, "color": "green", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "green", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.495439219700162, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_dd2aaf9463214bdda13975f1e99e3a81 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_43ee519cbea0032880421d3cc5787735 = $(`<div id="html_43ee519cbea0032880421d3cc5787735" style="width: 100.0%; height: 100.0%;">Passy (FR) — pop 11,613</div>`)[0];
+                popup_dd2aaf9463214bdda13975f1e99e3a81.setContent(html_43ee519cbea0032880421d3cc5787735);
+            
+        
+
+        circle_marker_cea2f1916c04db8f9e7067dd6dd0cb24.bindPopup(popup_dd2aaf9463214bdda13975f1e99e3a81)
+        ;
+
+        
+    
+    
+            var circle_marker_84db31e7d316bc8fcd2e7c85e8c254e7 = L.circleMarker(
+                [45.601701, 12.165212],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.492805105665603, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_02ba4187b30b4c2a585a1f20375647d3 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_cdc4b8e6a407b77eee0c6766c32044ea = $(`<div id="html_cdc4b8e6a407b77eee0c6766c32044ea" style="width: 100.0%; height: 100.0%;">Zero Branco (IT) — pop 11,578</div>`)[0];
+                popup_02ba4187b30b4c2a585a1f20375647d3.setContent(html_cdc4b8e6a407b77eee0c6766c32044ea);
+            
+        
+
+        circle_marker_84db31e7d316bc8fcd2e7c85e8c254e7.bindPopup(popup_02ba4187b30b4c2a585a1f20375647d3)
+        ;
+
+        
+    
+    
+            var circle_marker_b4c62aaccc52e65aa20e592f9a322f95 = L.circleMarker(
+                [46.8289, 12.76903],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.492353543259679, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_eba02c42542118c1c13414a07b73f4f8 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_95a3a0483dfe8fa5ab3dc99a34e5e914 = $(`<div id="html_95a3a0483dfe8fa5ab3dc99a34e5e914" style="width: 100.0%; height: 100.0%;">Lienz (AT) — pop 11,572</div>`)[0];
+                popup_eba02c42542118c1c13414a07b73f4f8.setContent(html_95a3a0483dfe8fa5ab3dc99a34e5e914);
+            
+        
+
+        circle_marker_b4c62aaccc52e65aa20e592f9a322f95.bindPopup(popup_eba02c42542118c1c13414a07b73f4f8)
+        ;
+
+        
+    
+    
+            var circle_marker_60d0cc2355fa7c7f7abd197e35ff24f9 = L.circleMarker(
+                [45.6173586, 12.5618873],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.488590523210307, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_ee844c085ff120eb9374ce329d05a1b7 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_5edcebaccb8e80dcf6e000fc9a1168fa = $(`<div id="html_5edcebaccb8e80dcf6e000fc9a1168fa" style="width: 100.0%; height: 100.0%;">Musile di Piave (IT) — pop 11,522</div>`)[0];
+                popup_ee844c085ff120eb9374ce329d05a1b7.setContent(html_5edcebaccb8e80dcf6e000fc9a1168fa);
+            
+        
+
+        circle_marker_60d0cc2355fa7c7f7abd197e35ff24f9.bindPopup(popup_ee844c085ff120eb9374ce329d05a1b7)
+        ;
+
+        
+    
+    
+            var circle_marker_681f4d61dec2ee2c3306b9ceff289d87 = L.circleMarker(
+                [47.33306, 9.63306],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.484902763561924, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_7ac212a742bc7158ca8b40e3257faa68 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_6541d334ad70f96fcc7d093bcdbde02e = $(`<div id="html_6541d334ad70f96fcc7d093bcdbde02e" style="width: 100.0%; height: 100.0%;">Götzis (AT) — pop 11,473</div>`)[0];
+                popup_7ac212a742bc7158ca8b40e3257faa68.setContent(html_6541d334ad70f96fcc7d093bcdbde02e);
+            
+        
+
+        circle_marker_681f4d61dec2ee2c3306b9ceff289d87.bindPopup(popup_7ac212a742bc7158ca8b40e3257faa68)
+        ;
+
+        
+    
+    
+            var circle_marker_25ad8e4273c0c89ac39124019da3b822 = L.circleMarker(
+                [45.45768, 11.90644],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.481967607923415, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_3cf04e732abb2b33a741e8385ea9c106 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_0b971a802a4ae962af9a49551e7d0c15 = $(`<div id="html_0b971a802a4ae962af9a49551e7d0c15" style="width: 100.0%; height: 100.0%;">Mejaniga (IT) — pop 11,434</div>`)[0];
+                popup_3cf04e732abb2b33a741e8385ea9c106.setContent(html_0b971a802a4ae962af9a49551e7d0c15);
+            
+        
+
+        circle_marker_25ad8e4273c0c89ac39124019da3b822.bindPopup(popup_3cf04e732abb2b33a741e8385ea9c106)
+        ;
+
+        
+    
+    
+            var circle_marker_95f30be2459bb01cb2a8e7aaa7d4bae4 = L.circleMarker(
+                [45.6848378, 12.2859442],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.474441567824673, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_36adfd15c96d78a1e0013a428c69e396 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_65742790698bc081cc3f812c48101b0e = $(`<div id="html_65742790698bc081cc3f812c48101b0e" style="width: 100.0%; height: 100.0%;">Carbonera (IT) — pop 11,334</div>`)[0];
+                popup_36adfd15c96d78a1e0013a428c69e396.setContent(html_65742790698bc081cc3f812c48101b0e);
+            
+        
+
+        circle_marker_95f30be2459bb01cb2a8e7aaa7d4bae4.bindPopup(popup_36adfd15c96d78a1e0013a428c69e396)
+        ;
+
+        
+    
+    
+            var circle_marker_570ecda8ec1d9c4d30cc2445d0dde360 = L.circleMarker(
+                [45.5320528, 11.4785807],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.474215786621711, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_a7fba3e085daefd797c08eb8bf609818 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_2ce5f7381fd211c4fbcf7ad230e11c4e = $(`<div id="html_2ce5f7381fd211c4fbcf7ad230e11c4e" style="width: 100.0%; height: 100.0%;">Creazzo (IT) — pop 11,331</div>`)[0];
+                popup_a7fba3e085daefd797c08eb8bf609818.setContent(html_2ce5f7381fd211c4fbcf7ad230e11c4e);
+            
+        
+
+        circle_marker_570ecda8ec1d9c4d30cc2445d0dde360.bindPopup(popup_a7fba3e085daefd797c08eb8bf609818)
+        ;
+
+        
+    
+    
+            var circle_marker_21347839be4292e9a5701418e8a82c1d = L.circleMarker(
+                [45.6118362, 11.5075805],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.4719579745920885, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_4e8c2ba38bd14fed4318f37c9c73123d = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_5ab296f0523c01c8053513772d88cf4e = $(`<div id="html_5ab296f0523c01c8053513772d88cf4e" style="width: 100.0%; height: 100.0%;">Caldogno (IT) — pop 11,301</div>`)[0];
+                popup_4e8c2ba38bd14fed4318f37c9c73123d.setContent(html_5ab296f0523c01c8053513772d88cf4e);
+            
+        
+
+        circle_marker_21347839be4292e9a5701418e8a82c1d.bindPopup(popup_4e8c2ba38bd14fed4318f37c9c73123d)
+        ;
+
+        
+    
+    
+            var circle_marker_c8dd4cd256478a9526ba42a0624b9f51 = L.circleMarker(
+                [45.4142322, 11.9507999],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.469248600156542, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_a31a33c9aea8f5fae0993c13151e3d32 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_9df5ec2aa84ff3fc2cad9ebd8670d9aa = $(`<div id="html_9df5ec2aa84ff3fc2cad9ebd8670d9aa" style="width: 100.0%; height: 100.0%;">Noventa Padovana (IT) — pop 11,265</div>`)[0];
+                popup_a31a33c9aea8f5fae0993c13151e3d32.setContent(html_9df5ec2aa84ff3fc2cad9ebd8670d9aa);
+            
+        
+
+        circle_marker_c8dd4cd256478a9526ba42a0624b9f51.bindPopup(popup_a31a33c9aea8f5fae0993c13151e3d32)
+        ;
+
+        
+    
+    
+            var circle_marker_859c785e130226a18c670561b9e627f4 = L.circleMarker(
+                [45.541496, 11.784404],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.468194954542718, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_a26e7ad7b9e82b7eddfcf8e80b916e40 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_91de77bb6345391ba38bb77bcdf5cfed = $(`<div id="html_91de77bb6345391ba38bb77bcdf5cfed" style="width: 100.0%; height: 100.0%;">Piazzola sul Brenta (IT) — pop 11,251</div>`)[0];
+                popup_a26e7ad7b9e82b7eddfcf8e80b916e40.setContent(html_91de77bb6345391ba38bb77bcdf5cfed);
+            
+        
+
+        circle_marker_859c785e130226a18c670561b9e627f4.bindPopup(popup_a26e7ad7b9e82b7eddfcf8e80b916e40)
+        ;
+
+        
+    
+    
+            var circle_marker_3417180eb5acc40495e8ff90e68829bc = L.circleMarker(
+                [46.27405, 13.12237],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.459916310434102, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_e5ca782c712f41d9f3b7d0cc63c57c5e = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_f65b0c831d31d221964b7a72921edb29 = $(`<div id="html_f65b0c831d31d221964b7a72921edb29" style="width: 100.0%; height: 100.0%;">Gemona (IT) — pop 11,141</div>`)[0];
+                popup_e5ca782c712f41d9f3b7d0cc63c57c5e.setContent(html_f65b0c831d31d221964b7a72921edb29);
+            
+        
+
+        circle_marker_3417180eb5acc40495e8ff90e68829bc.bindPopup(popup_e5ca782c712f41d9f3b7d0cc63c57c5e)
+        ;
+
+        
+    
+    
+            var circle_marker_7d8d69f081befcc61e2fbc26c21a830b = L.circleMarker(
+                [45.5220266, 11.7134998],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.457959540008429, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_84166a42f0aeb5a36a11a08b72d09605 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_cb936715ef8cdf0a902bcb84f5264378 = $(`<div id="html_cb936715ef8cdf0a902bcb84f5264378" style="width: 100.0%; height: 100.0%;">Camisano Vicentino (IT) — pop 11,115</div>`)[0];
+                popup_84166a42f0aeb5a36a11a08b72d09605.setContent(html_cb936715ef8cdf0a902bcb84f5264378);
+            
+        
+
+        circle_marker_7d8d69f081befcc61e2fbc26c21a830b.bindPopup(popup_84166a42f0aeb5a36a11a08b72d09605)
+        ;
+
+        
+    
+    
+            var circle_marker_9584d27812a57b1e46df8d85fab56f79 = L.circleMarker(
+                [46.1113355, 12.9016287],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.455852248780782, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_2c0c6c894bda4017f83ea680d2621e0a = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_e142e881d1106d1438e3dfd4c9b8f2fc = $(`<div id="html_e142e881d1106d1438e3dfd4c9b8f2fc" style="width: 100.0%; height: 100.0%;">Spilimbergo / Spilimberc (IT) — pop 11,087</div>`)[0];
+                popup_2c0c6c894bda4017f83ea680d2621e0a.setContent(html_e142e881d1106d1438e3dfd4c9b8f2fc);
+            
+        
+
+        circle_marker_9584d27812a57b1e46df8d85fab56f79.bindPopup(popup_2c0c6c894bda4017f83ea680d2621e0a)
+        ;
+
+        
+    
+    
+            var circle_marker_ca3bdf83510fdc019e3148d9faee1c0c = L.circleMarker(
+                [47.28333, 11.43333],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.455475946775844, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_b7f286368fc832e3f42d809c9f84cc20 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_6abbd0e404616f0f387a57b57576c4d5 = $(`<div id="html_6abbd0e404616f0f387a57b57576c4d5" style="width: 100.0%; height: 100.0%;">Arzl (AT) — pop 11,082</div>`)[0];
+                popup_b7f286368fc832e3f42d809c9f84cc20.setContent(html_6abbd0e404616f0f387a57b57576c4d5);
+            
+        
+
+        circle_marker_ca3bdf83510fdc019e3148d9faee1c0c.bindPopup(popup_b7f286368fc832e3f42d809c9f84cc20)
+        ;
+
+        
+    
+    
+            var circle_marker_18ca85632580e727870b2cc34077b536 = L.circleMarker(
+                [46.2770072, 13.1401049],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.446595219459329, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_2f142abd68c81120929d32798a6d8a0b = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_fe5c5fb63c0398353cc5b8fd1c34d683 = $(`<div id="html_fe5c5fb63c0398353cc5b8fd1c34d683" style="width: 100.0%; height: 100.0%;">Gemona del Friuli / Glemone (IT) — pop 10,964</div>`)[0];
+                popup_2f142abd68c81120929d32798a6d8a0b.setContent(html_fe5c5fb63c0398353cc5b8fd1c34d683);
+            
+        
+
+        circle_marker_18ca85632580e727870b2cc34077b536.bindPopup(popup_2f142abd68c81120929d32798a6d8a0b)
+        ;
+
+        
+    
+    
+            var circle_marker_cd2a0b94465fac924e40942bc505cdd1 = L.circleMarker(
+                [45.60419, 13.76754],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.44396110542477, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_5ff0d3a779b0100a42e2e3c40524b2f8 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_ae1f1545d97f78da0e65a880f9de701d = $(`<div id="html_ae1f1545d97f78da0e65a880f9de701d" style="width: 100.0%; height: 100.0%;">Muggia (IT) — pop 10,929</div>`)[0];
+                popup_5ff0d3a779b0100a42e2e3c40524b2f8.setContent(html_ae1f1545d97f78da0e65a880f9de701d);
+            
+        
+
+        circle_marker_cd2a0b94465fac924e40942bc505cdd1.bindPopup(popup_5ff0d3a779b0100a42e2e3c40524b2f8)
+        ;
+
+        
+    
+    
+            var circle_marker_e9c7ef879ba10e7201054ff805e6fe98 = L.circleMarker(
+                [45.77663, 12.6105482],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.431844180865796, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_7a3728df04e6f98bea19f32264252be0 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_801206221a34c8be0c9b8a00817748d3 = $(`<div id="html_801206221a34c8be0c9b8a00817748d3" style="width: 100.0%; height: 100.0%;">Motta di Livenza (IT) — pop 10,768</div>`)[0];
+                popup_7a3728df04e6f98bea19f32264252be0.setContent(html_801206221a34c8be0c9b8a00817748d3);
+            
+        
+
+        circle_marker_e9c7ef879ba10e7201054ff805e6fe98.bindPopup(popup_7a3728df04e6f98bea19f32264252be0)
+        ;
+
+        
+    
+    
+            var circle_marker_7fc91d3dd3bc61d45d7bdf3cac76a990 = L.circleMarker(
+                [45.5046266, 12.2820457],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.428231681618399, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_80af25e0dcfcc31caf4bbc1f1fdb8db5 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_165008be2613275ba9ceb1670db4b191 = $(`<div id="html_165008be2613275ba9ceb1670db4b191" style="width: 100.0%; height: 100.0%;">Favaro Veneto (IT) — pop 10,720</div>`)[0];
+                popup_80af25e0dcfcc31caf4bbc1f1fdb8db5.setContent(html_165008be2613275ba9ceb1670db4b191);
+            
+        
+
+        circle_marker_7fc91d3dd3bc61d45d7bdf3cac76a990.bindPopup(popup_80af25e0dcfcc31caf4bbc1f1fdb8db5)
+        ;
+
+        
+    
+    
+            var circle_marker_132cde66f7b7590fd66ec28b3b659bd8 = L.circleMarker(
+                [46.42679, 11.33841],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.427479077608526, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_25595cbc6d1d912af59748a99765bb2c = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_e560c41d9f54b56bec8c7e968a33fd8b = $(`<div id="html_e560c41d9f54b56bec8c7e968a33fd8b" style="width: 100.0%; height: 100.0%;">Laives (IT) — pop 10,710</div>`)[0];
+                popup_25595cbc6d1d912af59748a99765bb2c.setContent(html_e560c41d9f54b56bec8c7e968a33fd8b);
+            
+        
+
+        circle_marker_132cde66f7b7590fd66ec28b3b659bd8.bindPopup(popup_25595cbc6d1d912af59748a99765bb2c)
+        ;
+
+        
+    
+    
+            var circle_marker_a53ea5eeb6b8dc5a89633a3110d703fa = L.circleMarker(
+                [45.4514083, 12.1710686],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.415964236257451, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_ab870bb5867628bdc6562e1dd89277e6 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_b57a7b4181e5e6c2f0a2ba9a53a052ae = $(`<div id="html_b57a7b4181e5e6c2f0a2ba9a53a052ae" style="width: 100.0%; height: 100.0%;">Oriago (IT) — pop 10,557</div>`)[0];
+                popup_ab870bb5867628bdc6562e1dd89277e6.setContent(html_b57a7b4181e5e6c2f0a2ba9a53a052ae);
+            
+        
+
+        circle_marker_a53ea5eeb6b8dc5a89633a3110d703fa.bindPopup(popup_ab870bb5867628bdc6562e1dd89277e6)
+        ;
+
+        
+    
+    
+            var circle_marker_bf9d779ed34074b1ed88f6e996dd3aed = L.circleMarker(
+                [45.50694, 12.64694],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.413405382623878, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_681ada81da40472f4c5199877ca92ee7 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_950aac3543176a9dc9aea9c8d6dc938f = $(`<div id="html_950aac3543176a9dc9aea9c8d6dc938f" style="width: 100.0%; height: 100.0%;">Lido di Jesolo (IT) — pop 10,523</div>`)[0];
+                popup_681ada81da40472f4c5199877ca92ee7.setContent(html_950aac3543176a9dc9aea9c8d6dc938f);
+            
+        
+
+        circle_marker_bf9d779ed34074b1ed88f6e996dd3aed.bindPopup(popup_681ada81da40472f4c5199877ca92ee7)
+        ;
+
+        
+    
+    
+            var circle_marker_52ef1868f0da46dffbc0d194b3d950d4 = L.circleMarker(
+                [47.24504, 10.73974],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.411975435005118, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_8fedeaaf2b9876621b3168b55378cc77 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_e29eedf4c000c7326eb307fbdd575e81 = $(`<div id="html_e29eedf4c000c7326eb307fbdd575e81" style="width: 100.0%; height: 100.0%;">Imst (AT) — pop 10,504</div>`)[0];
+                popup_8fedeaaf2b9876621b3168b55378cc77.setContent(html_e29eedf4c000c7326eb307fbdd575e81);
+            
+        
+
+        circle_marker_52ef1868f0da46dffbc0d194b3d950d4.bindPopup(popup_8fedeaaf2b9876621b3168b55378cc77)
+        ;
+
+        
+    
+    
+            var circle_marker_7164f13f91c3f77b6a2c3b50304143b7 = L.circleMarker(
+                [46.1372, 9.57415],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.40956710217352, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_472f9f69e96bb852c19eee0b3b9b8b7f = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_19813c7227c6722ce846c1881810ae1e = $(`<div id="html_19813c7227c6722ce846c1881810ae1e" style="width: 100.0%; height: 100.0%;">Morbegno (IT) — pop 10,472</div>`)[0];
+                popup_472f9f69e96bb852c19eee0b3b9b8b7f.setContent(html_19813c7227c6722ce846c1881810ae1e);
+            
+        
+
+        circle_marker_7164f13f91c3f77b6a2c3b50304143b7.bindPopup(popup_472f9f69e96bb852c19eee0b3b9b8b7f)
+        ;
+
+        
+    
+    
+            var circle_marker_3450b45c9880c51c91a794135fec39ff = L.circleMarker(
+                [46.4053676, 13.0158357],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.407158769341923, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_d1ca8e2fca155ceafd3612d8eb565b88 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_98cedc48acaf8df932314f6c44cbeb77 = $(`<div id="html_98cedc48acaf8df932314f6c44cbeb77" style="width: 100.0%; height: 100.0%;">Tolmezzo / Tumieç (IT) — pop 10,440</div>`)[0];
+                popup_d1ca8e2fca155ceafd3612d8eb565b88.setContent(html_98cedc48acaf8df932314f6c44cbeb77);
+            
+        
+
+        circle_marker_3450b45c9880c51c91a794135fec39ff.bindPopup(popup_d1ca8e2fca155ceafd3612d8eb565b88)
+        ;
+
+        
+    
+    
+            var circle_marker_4ca21981bd63d9942fe7ddb589523946 = L.circleMarker(
+                [46.16644, 12.70602],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.403772051297489, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_d0b35303d2a3b5c2f603f6e05f2d25d8 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_d6853341408d9cb109efff3f8ff9623e = $(`<div id="html_d6853341408d9cb109efff3f8ff9623e" style="width: 100.0%; height: 100.0%;">Maniago (IT) — pop 10,395</div>`)[0];
+                popup_d0b35303d2a3b5c2f603f6e05f2d25d8.setContent(html_d6853341408d9cb109efff3f8ff9623e);
+            
+        
+
+        circle_marker_4ca21981bd63d9942fe7ddb589523946.bindPopup(popup_d0b35303d2a3b5c2f603f6e05f2d25d8)
+        ;
+
+        
+    
+    
+            var circle_marker_c32aa376157731fcc2781ced3bad83a4 = L.circleMarker(
+                [45.9014131, 11.9955123],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.403245228490578, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_3b0eaa57b729111e91d3ec1b0f5553d8 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_0708ffa23921ff5b3c13351ad693003f = $(`<div id="html_0708ffa23921ff5b3c13351ad693003f" style="width: 100.0%; height: 100.0%;">Valdobbiadene (IT) — pop 10,388</div>`)[0];
+                popup_3b0eaa57b729111e91d3ec1b0f5553d8.setContent(html_0708ffa23921ff5b3c13351ad693003f);
+            
+        
+
+        circle_marker_c32aa376157731fcc2781ced3bad83a4.bindPopup(popup_3b0eaa57b729111e91d3ec1b0f5553d8)
+        ;
+
+        
+    
+    
+            var circle_marker_173f44b72d207f164373c40d06bef643 = L.circleMarker(
+                [47.47572, 9.72941],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.3941387199711, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_7e8872d915fa38316fa16e63b563e0b5 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_fa7f4693f31109ee98f30622d807a402 = $(`<div id="html_fa7f4693f31109ee98f30622d807a402" style="width: 100.0%; height: 100.0%;">Lauterach (AT) — pop 10,267</div>`)[0];
+                popup_7e8872d915fa38316fa16e63b563e0b5.setContent(html_fa7f4693f31109ee98f30622d807a402);
+            
+        
+
+        circle_marker_173f44b72d207f164373c40d06bef643.bindPopup(popup_7e8872d915fa38316fa16e63b563e0b5)
+        ;
+
+        
+    
+    
+            var circle_marker_f3b6beafecb6a02306f98ba95c0a55ca = L.circleMarker(
+                [45.71541, 12.20444],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.391956168342465, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_e472645319c34b7dfbac64b1792a4acc = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_829e996e5a74759a4d260faaae0dfe2e = $(`<div id="html_829e996e5a74759a4d260faaae0dfe2e" style="width: 100.0%; height: 100.0%;">Ponzano Veneto (IT) — pop 10,238</div>`)[0];
+                popup_e472645319c34b7dfbac64b1792a4acc.setContent(html_829e996e5a74759a4d260faaae0dfe2e);
+            
+        
+
+        circle_marker_f3b6beafecb6a02306f98ba95c0a55ca.bindPopup(popup_e472645319c34b7dfbac64b1792a4acc)
+        ;
+
+        
+    
+    
+            var circle_marker_23323728b03d4ea498eba5bd01a0655a = L.circleMarker(
+                [45.710824, 12.2237501],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.391956168342465, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_b0a06a451ef7d7fbce4bd8d55a1f01d7 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_931f895715930768556ea070d475e9d9 = $(`<div id="html_931f895715930768556ea070d475e9d9" style="width: 100.0%; height: 100.0%;">Ponzano (IT) — pop 10,238</div>`)[0];
+                popup_b0a06a451ef7d7fbce4bd8d55a1f01d7.setContent(html_931f895715930768556ea070d475e9d9);
+            
+        
+
+        circle_marker_23323728b03d4ea498eba5bd01a0655a.bindPopup(popup_b0a06a451ef7d7fbce4bd8d55a1f01d7)
+        ;
+
+        
+    
+    
+            var circle_marker_99d809cec4edbfcf4a85335b4aca25aa = L.circleMarker(
+                [45.4948512, 11.7975235],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.390375699921729, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_3509021d0b24ac560bf967afedcb00bb = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_c6c4dcd6ca5dc2374497facc96b7333f = $(`<div id="html_c6c4dcd6ca5dc2374497facc96b7333f" style="width: 100.0%; height: 100.0%;">Villafranca Padovana (IT) — pop 10,217</div>`)[0];
+                popup_3509021d0b24ac560bf967afedcb00bb.setContent(html_c6c4dcd6ca5dc2374497facc96b7333f);
+            
+        
+
+        circle_marker_99d809cec4edbfcf4a85335b4aca25aa.bindPopup(popup_3509021d0b24ac560bf967afedcb00bb)
+        ;
+
+        
+    
+    
+            var circle_marker_a9cd9db96444e85bade8f12e56c6f777 = L.circleMarker(
+                [45.6286685, 11.4431478],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.390149918718767, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_af9d7951f4addf16eeac6ab8688da9fe = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_718c230ea5c41fa3334cf4399fca8795 = $(`<div id="html_718c230ea5c41fa3334cf4399fca8795" style="width: 100.0%; height: 100.0%;">Isola Vicentina (IT) — pop 10,214</div>`)[0];
+                popup_af9d7951f4addf16eeac6ab8688da9fe.setContent(html_718c230ea5c41fa3334cf4399fca8795);
+            
+        
+
+        circle_marker_a9cd9db96444e85bade8f12e56c6f777.bindPopup(popup_af9d7951f4addf16eeac6ab8688da9fe)
+        ;
+
+        
+    
+    
+            var circle_marker_f7d627c90bc868f1526f712c3338e52d = L.circleMarker(
+                [45.5416702, 11.9112369],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.390149918718767, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_c57ad49b51cf47fbfb6c2c3a86414097 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_b42e28b262a0325b30e8207d9df1332e = $(`<div id="html_b42e28b262a0325b30e8207d9df1332e" style="width: 100.0%; height: 100.0%;">San Giorgio delle Pertiche (IT) — pop 10,214</div>`)[0];
+                popup_c57ad49b51cf47fbfb6c2c3a86414097.setContent(html_b42e28b262a0325b30e8207d9df1332e);
+            
+        
+
+        circle_marker_f7d627c90bc868f1526f712c3338e52d.bindPopup(popup_c57ad49b51cf47fbfb6c2c3a86414097)
+        ;
+
+        
+    
+    
+            var circle_marker_9aaf60a3ee02fff90453972ce918f0cc = L.circleMarker(
+                [45.8533795, 10.9753961],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.389924137515805, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_1ee1fbbb724698fb8438865267bffea5 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_8dacf136b2b0740584cd1fa945a0e457 = $(`<div id="html_8dacf136b2b0740584cd1fa945a0e457" style="width: 100.0%; height: 100.0%;">Mori (IT) — pop 10,211</div>`)[0];
+                popup_1ee1fbbb724698fb8438865267bffea5.setContent(html_8dacf136b2b0740584cd1fa945a0e457);
+            
+        
+
+        circle_marker_9aaf60a3ee02fff90453972ce918f0cc.bindPopup(popup_1ee1fbbb724698fb8438865267bffea5)
+        ;
+
+        
+    
+    
+            var circle_marker_85ba13b5dc86ddf5909a87ad26db121b = L.circleMarker(
+                [45.6533706, 12.2959606],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.386612679872359, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_38c35fc254b7018eeab8b512cb9d40f0 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_d64ea998d45e801356b9c2d06ee762b4 = $(`<div id="html_d64ea998d45e801356b9c2d06ee762b4" style="width: 100.0%; height: 100.0%;">Silea (IT) — pop 10,167</div>`)[0];
+                popup_38c35fc254b7018eeab8b512cb9d40f0.setContent(html_d64ea998d45e801356b9c2d06ee762b4);
+            
+        
+
+        circle_marker_85ba13b5dc86ddf5909a87ad26db121b.bindPopup(popup_38c35fc254b7018eeab8b512cb9d40f0)
+        ;
+
+        
+    
+    
+            var circle_marker_a4b931a6bf55079d9c1a55a98d963c64 = L.circleMarker(
+                [45.7780578, 12.119815],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.38540851345656, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_3b23a098c64ef156cd7166fbd3710788 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_22603d6a8f5865bb837b9b2d2f28ac40 = $(`<div id="html_22603d6a8f5865bb837b9b2d2f28ac40" style="width: 100.0%; height: 100.0%;">Volpago del Montello (IT) — pop 10,151</div>`)[0];
+                popup_3b23a098c64ef156cd7166fbd3710788.setContent(html_22603d6a8f5865bb837b9b2d2f28ac40);
+            
+        
+
+        circle_marker_a4b931a6bf55079d9c1a55a98d963c64.bindPopup(popup_3b23a098c64ef156cd7166fbd3710788)
+        ;
+
+        
+    
+    
+            var circle_marker_5eaa27eeb15323ec35d011b3ea86f145 = L.circleMarker(
+                [46.11098, 12.0971545],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.383000180624962, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_8bfc961ac371e68c595e4ee443921030 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_ac35aecd5f9101396a5b625322c3a354 = $(`<div id="html_ac35aecd5f9101396a5b625322c3a354" style="width: 100.0%; height: 100.0%;">Sedico (IT) — pop 10,119</div>`)[0];
+                popup_8bfc961ac371e68c595e4ee443921030.setContent(html_ac35aecd5f9101396a5b625322c3a354);
+            
+        
+
+        circle_marker_5eaa27eeb15323ec35d011b3ea86f145.bindPopup(popup_8bfc961ac371e68c595e4ee443921030)
+        ;
+
+        
+    
+    
+            var circle_marker_b2d0b62bbefe32e2d565b883ea4a8888 = L.circleMarker(
+                [47.6831625, 11.5763967],
+                {"bubblingMouseEvents": true, "color": "blue", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "blue", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.379839243783491, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_0848719839b911e0dde9a817c7554f6f = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_0563e20f4173e6299be27bf38b08f845 = $(`<div id="html_0563e20f4173e6299be27bf38b08f845" style="width: 100.0%; height: 100.0%;">Lenggries (DE) — pop 10,077</div>`)[0];
+                popup_0848719839b911e0dde9a817c7554f6f.setContent(html_0563e20f4173e6299be27bf38b08f845);
+            
+        
+
+        circle_marker_b2d0b62bbefe32e2d565b883ea4a8888.bindPopup(popup_0848719839b911e0dde9a817c7554f6f)
+        ;
+
+        
+    
+    
+            var circle_marker_fe976777aaaddbc28ef3f6f6cee82de5 = L.circleMarker(
+                [45.6452121, 12.1664816],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.362303570353423, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_17ee8fa63505167c499f284e9cd67aac = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_48eb01ca250654c0422c5b7f8f6bda48 = $(`<div id="html_48eb01ca250654c0422c5b7f8f6bda48" style="width: 100.0%; height: 100.0%;">Quinto di Treviso (IT) — pop 9,844</div>`)[0];
+                popup_17ee8fa63505167c499f284e9cd67aac.setContent(html_48eb01ca250654c0422c5b7f8f6bda48);
+            
+        
+
+        circle_marker_fe976777aaaddbc28ef3f6f6cee82de5.bindPopup(popup_17ee8fa63505167c499f284e9cd67aac)
+        ;
+
+        
+    
+    
+            var circle_marker_5a56f3130740dd53c91c1572d697edba = L.circleMarker(
+                [45.8907463, 12.3338437],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.361776747546511, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_6c9f2e44a61dcde18d94eedb18cec072 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_c2c32fc977ba3ebd63657918fe3557e2 = $(`<div id="html_c2c32fc977ba3ebd63657918fe3557e2" style="width: 100.0%; height: 100.0%;">San Vendemiano (IT) — pop 9,837</div>`)[0];
+                popup_6c9f2e44a61dcde18d94eedb18cec072.setContent(html_c2c32fc977ba3ebd63657918fe3557e2);
+            
+        
+
+        circle_marker_5a56f3130740dd53c91c1572d697edba.bindPopup(popup_6c9f2e44a61dcde18d94eedb18cec072)
+        ;
+
+        
+    
+    
+            var circle_marker_8914751e4a2207955811cef21f11906e = L.circleMarker(
+                [45.8408562, 12.3512554],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.3485309169727255, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_44d1ee86e58bf7eae3b878c49e3eec28 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_46063fde374f135b4f1b29a068c09c24 = $(`<div id="html_46063fde374f135b4f1b29a068c09c24" style="width: 100.0%; height: 100.0%;">Mareno di Piave (IT) — pop 9,661</div>`)[0];
+                popup_44d1ee86e58bf7eae3b878c49e3eec28.setContent(html_46063fde374f135b4f1b29a068c09c24);
+            
+        
+
+        circle_marker_8914751e4a2207955811cef21f11906e.bindPopup(popup_44d1ee86e58bf7eae3b878c49e3eec28)
+        ;
+
+        
+    
+    
+            var circle_marker_582f8b3b34e0386459d421b7facefad7 = L.circleMarker(
+                [47.40724, 10.27939],
+                {"bubblingMouseEvents": true, "color": "blue", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "blue", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.341832741284845, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_d1ee105bc86cbbf18e2d520327785ff1 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_fe5b60fd4d6c7d66fb4fdbdc3a016e80 = $(`<div id="html_fe5b60fd4d6c7d66fb4fdbdc3a016e80" style="width: 100.0%; height: 100.0%;">Oberstdorf (DE) — pop 9,572</div>`)[0];
+                popup_d1ee105bc86cbbf18e2d520327785ff1.setContent(html_fe5b60fd4d6c7d66fb4fdbdc3a016e80);
+            
+        
+
+        circle_marker_582f8b3b34e0386459d421b7facefad7.bindPopup(popup_d1ee105bc86cbbf18e2d520327785ff1)
+        ;
+
+        
+    
+    
+            var circle_marker_f494a3bf984e6019a011f76b6e6a67b8 = L.circleMarker(
+                [45.6075204, 11.9994148],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.338972846047324, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_ca6b0af042d50adf674719fb84626b44 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_feb6089e7c7f792423e6e0cc7d28ef34 = $(`<div id="html_feb6089e7c7f792423e6e0cc7d28ef34" style="width: 100.0%; height: 100.0%;">Piombino Dese (IT) — pop 9,534</div>`)[0];
+                popup_ca6b0af042d50adf674719fb84626b44.setContent(html_feb6089e7c7f792423e6e0cc7d28ef34);
+            
+        
+
+        circle_marker_f494a3bf984e6019a011f76b6e6a67b8.bindPopup(popup_ca6b0af042d50adf674719fb84626b44)
+        ;
+
+        
+    
+    
+            var circle_marker_ab60074a813e2193bb0ef3986a673b90 = L.circleMarker(
+                [45.6345748, 11.9554316],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.338069721235475, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_59f79db62edb299dbd172b30b0973f26 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_b867da01ad7e6673aed63213c21a446d = $(`<div id="html_b867da01ad7e6673aed63213c21a446d" style="width: 100.0%; height: 100.0%;">Resana (IT) — pop 9,522</div>`)[0];
+                popup_59f79db62edb299dbd172b30b0973f26.setContent(html_b867da01ad7e6673aed63213c21a446d);
+            
+        
+
+        circle_marker_ab60074a813e2193bb0ef3986a673b90.bindPopup(popup_59f79db62edb299dbd172b30b0973f26)
+        ;
+
+        
+    
+    
+            var circle_marker_c3a9a30a35da6b3675f90aaac89185fa = L.circleMarker(
+                [46.11345, 12.89241],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.330543681136733, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_9222f5d10483f5f3ef2495fad151c07f = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_40c845d2f3a072e6d0e796b27af5b42b = $(`<div id="html_40c845d2f3a072e6d0e796b27af5b42b" style="width: 100.0%; height: 100.0%;">Spilimbergo (IT) — pop 9,422</div>`)[0];
+                popup_9222f5d10483f5f3ef2495fad151c07f.setContent(html_40c845d2f3a072e6d0e796b27af5b42b);
+            
+        
+
+        circle_marker_c3a9a30a35da6b3675f90aaac89185fa.bindPopup(popup_9222f5d10483f5f3ef2495fad151c07f)
+        ;
+
+        
+    
+    
+            var circle_marker_30fe6136c1bfa863941af957b3dd746d = L.circleMarker(
+                [46.59194, 14.26917],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.329414775121922, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_bd8a32827400be3fb3170b52f5f16bf3 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_864ed9cd682d33625223f9ee907861b4 = $(`<div id="html_864ed9cd682d33625223f9ee907861b4" style="width: 100.0%; height: 100.0%;">Viktring (AT) — pop 9,407</div>`)[0];
+                popup_bd8a32827400be3fb3170b52f5f16bf3.setContent(html_864ed9cd682d33625223f9ee907861b4);
+            
+        
+
+        circle_marker_30fe6136c1bfa863941af957b3dd746d.bindPopup(popup_bd8a32827400be3fb3170b52f5f16bf3)
+        ;
+
+        
+    
+    
+            var circle_marker_dfdd919cd0fa96a8a56b613506110464 = L.circleMarker(
+                [45.7494106, 12.3193327],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.327382744295262, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_b793fc6ba24065b34de6155a488529d3 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_e8e764d2b11d603859d8975ac6d228d6 = $(`<div id="html_e8e764d2b11d603859d8975ac6d228d6" style="width: 100.0%; height: 100.0%;">Maserada sul Piave (IT) — pop 9,380</div>`)[0];
+                popup_b793fc6ba24065b34de6155a488529d3.setContent(html_e8e764d2b11d603859d8975ac6d228d6);
+            
+        
+
+        circle_marker_dfdd919cd0fa96a8a56b613506110464.bindPopup(popup_b793fc6ba24065b34de6155a488529d3)
+        ;
+
+        
+    
+    
+            var circle_marker_2ebb42412f1ecf2c05d8aa51e932e1d9 = L.circleMarker(
+                [45.69259, 11.4290346],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.324748630260702, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_1fa732834cfaa67f8362ca4d0c4deaff = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_f85ec1ac290fed78c608772d6ffd99cb = $(`<div id="html_f85ec1ac290fed78c608772d6ffd99cb" style="width: 100.0%; height: 100.0%;">Marano Vicentino (IT) — pop 9,345</div>`)[0];
+                popup_1fa732834cfaa67f8362ca4d0c4deaff.setContent(html_f85ec1ac290fed78c608772d6ffd99cb);
+            
+        
+
+        circle_marker_2ebb42412f1ecf2c05d8aa51e932e1d9.bindPopup(popup_1fa732834cfaa67f8362ca4d0c4deaff)
+        ;
+
+        
+    
+    
+            var circle_marker_50145748be71d6ef50131d2a922a5033 = L.circleMarker(
+                [45.75727, 11.76208],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.323920765849841, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_9af0e180dacf371a7205a56bcd627af6 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_e2a6784a91cf842073924391ba3a98cc = $(`<div id="html_e2a6784a91cf842073924391ba3a98cc" style="width: 100.0%; height: 100.0%;">San Zeno-San Giuseppe (IT) — pop 9,334</div>`)[0];
+                popup_9af0e180dacf371a7205a56bcd627af6.setContent(html_e2a6784a91cf842073924391ba3a98cc);
+            
+        
+
+        circle_marker_50145748be71d6ef50131d2a922a5033.bindPopup(popup_9af0e180dacf371a7205a56bcd627af6)
+        ;
+
+        
+    
+    
+            var circle_marker_8b06a284c9e2d713a22fda6cc96865e8 = L.circleMarker(
+                [45.92865, 12.73811],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.322340297429105, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_18083be3d5f4b938c20a412c96552fe1 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_bfcce9f04851233f7a83658f623a2c3f = $(`<div id="html_bfcce9f04851233f7a83658f623a2c3f" style="width: 100.0%; height: 100.0%;">Fiume Veneto (IT) — pop 9,313</div>`)[0];
+                popup_18083be3d5f4b938c20a412c96552fe1.setContent(html_bfcce9f04851233f7a83658f623a2c3f);
+            
+        
+
+        circle_marker_8b06a284c9e2d713a22fda6cc96865e8.bindPopup(popup_18083be3d5f4b938c20a412c96552fe1)
+        ;
+
+        
+    
+    
+            var circle_marker_98f12abf8cbbf3d887b92f6632ed7308 = L.circleMarker(
+                [45.7284237, 11.8655848],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.322114516226143, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_16a67ed8f0e5da7ce5029d1be1965a24 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_daba8a2df7aa821771848de4db165208 = $(`<div id="html_daba8a2df7aa821771848de4db165208" style="width: 100.0%; height: 100.0%;">Loria (IT) — pop 9,310</div>`)[0];
+                popup_16a67ed8f0e5da7ce5029d1be1965a24.setContent(html_daba8a2df7aa821771848de4db165208);
+            
+        
+
+        circle_marker_98f12abf8cbbf3d887b92f6632ed7308.bindPopup(popup_16a67ed8f0e5da7ce5029d1be1965a24)
+        ;
+
+        
+    
+    
+            var circle_marker_1026efe8da6e5ed30a19be00761f67f1 = L.circleMarker(
+                [45.6778456, 12.1033127],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.321286651815281, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_fa7229b49f9232159f80acfc29836ce3 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_1c93d960daa0dec0a9ac16d00c0c12a4 = $(`<div id="html_1c93d960daa0dec0a9ac16d00c0c12a4" style="width: 100.0%; height: 100.0%;">Istrana (IT) — pop 9,299</div>`)[0];
+                popup_fa7229b49f9232159f80acfc29836ce3.setContent(html_1c93d960daa0dec0a9ac16d00c0c12a4);
+            
+        
+
+        circle_marker_1026efe8da6e5ed30a19be00761f67f1.bindPopup(popup_fa7229b49f9232159f80acfc29836ce3)
+        ;
+
+        
+    
+    
+            var circle_marker_788e859584d0a94a6358f74faab86cb1 = L.circleMarker(
+                [46.09019, 13.42861],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.320609308206394, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_d76e561d99de681f6d76091fee64190d = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_197b3a9a26c9f2dcc681c74a4a6e6abe = $(`<div id="html_197b3a9a26c9f2dcc681c74a4a6e6abe" style="width: 100.0%; height: 100.0%;">Cividale del Friuli (IT) — pop 9,290</div>`)[0];
+                popup_d76e561d99de681f6d76091fee64190d.setContent(html_197b3a9a26c9f2dcc681c74a4a6e6abe);
+            
+        
+
+        circle_marker_788e859584d0a94a6358f74faab86cb1.bindPopup(popup_d76e561d99de681f6d76091fee64190d)
+        ;
+
+        
+    
+    
+            var circle_marker_c77c5fcc774a043ad0cd3e2753fb2d7f = L.circleMarker(
+                [47.28333, 11.45],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.313083268107652, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_3c2ecc221011127279b3e7deb94ea49b = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_1badf3299829b04dbd38085d40bb56a9 = $(`<div id="html_1badf3299829b04dbd38085d40bb56a9" style="width: 100.0%; height: 100.0%;">Rum (AT) — pop 9,190</div>`)[0];
+                popup_3c2ecc221011127279b3e7deb94ea49b.setContent(html_1badf3299829b04dbd38085d40bb56a9);
+            
+        
+
+        circle_marker_c77c5fcc774a043ad0cd3e2753fb2d7f.bindPopup(popup_3c2ecc221011127279b3e7deb94ea49b)
+        ;
+
+        
+    
+    
+            var circle_marker_c55b782ed1c239aa815b038514fdcaf5 = L.circleMarker(
+                [45.8491741, 12.2849283],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.310148112469143, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_cdd90c98b7c5e53566581574fd4615a7 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_bcb34ad7cd1e03b8e12c214e69eabbe8 = $(`<div id="html_bcb34ad7cd1e03b8e12c214e69eabbe8" style="width: 100.0%; height: 100.0%;">Santa Lucia di Piave (IT) — pop 9,151</div>`)[0];
+                popup_cdd90c98b7c5e53566581574fd4615a7.setContent(html_bcb34ad7cd1e03b8e12c214e69eabbe8);
+            
+        
+
+        circle_marker_c55b782ed1c239aa815b038514fdcaf5.bindPopup(popup_cdd90c98b7c5e53566581574fd4615a7)
+        ;
+
+        
+    
+    
+            var circle_marker_87b7b2f60f24ec9e87114cab1c1d3d2e = L.circleMarker(
+                [45.41429, 11.95101],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.308642904449395, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_0d8f8ec2f2c7522aa45c567f1cb9bd8f = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_9a49c8eb483c30c78f4c84147a494886 = $(`<div id="html_9a49c8eb483c30c78f4c84147a494886" style="width: 100.0%; height: 100.0%;">Noventa (IT) — pop 9,131</div>`)[0];
+                popup_0d8f8ec2f2c7522aa45c567f1cb9bd8f.setContent(html_9a49c8eb483c30c78f4c84147a494886);
+            
+        
+
+        circle_marker_87b7b2f60f24ec9e87114cab1c1d3d2e.bindPopup(popup_0d8f8ec2f2c7522aa45c567f1cb9bd8f)
+        ;
+
+        
+    
+    
+            var circle_marker_b44bd3bb5688ad80cd5d651f02dbb1f0 = L.circleMarker(
+                [45.8007265, 11.9142444],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.308417123246433, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_82510dc34b39a8097cbe503cb9b4eec8 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_f42dd2a993c0a43a5bc2ab707b5e420e = $(`<div id="html_f42dd2a993c0a43a5bc2ab707b5e420e" style="width: 100.0%; height: 100.0%;">Asolo (IT) — pop 9,128</div>`)[0];
+                popup_82510dc34b39a8097cbe503cb9b4eec8.setContent(html_f42dd2a993c0a43a5bc2ab707b5e420e);
+            
+        
+
+        circle_marker_b44bd3bb5688ad80cd5d651f02dbb1f0.bindPopup(popup_82510dc34b39a8097cbe503cb9b4eec8)
+        ;
+
+        
+    
+    
+            var circle_marker_fe971d6d1d418ce9ffaf33cdc2c4424c = L.circleMarker(
+                [45.5951803, 11.5805788],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.30615931121681, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_a7c1a8d0e46289a354e52ba63f219800 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_43baced90cf82c1db74b496a2c792bd3 = $(`<div id="html_43baced90cf82c1db74b496a2c792bd3" style="width: 100.0%; height: 100.0%;">Monticello Conte Otto (IT) — pop 9,098</div>`)[0];
+                popup_a7c1a8d0e46289a354e52ba63f219800.setContent(html_43baced90cf82c1db74b496a2c792bd3);
+            
+        
+
+        circle_marker_fe971d6d1d418ce9ffaf33cdc2c4424c.bindPopup(popup_a7c1a8d0e46289a354e52ba63f219800)
+        ;
+
+        
+    
+    
+            var circle_marker_c8281010395bf4c3001d32cbdef6f809 = L.circleMarker(
+                [46.1397416, 11.1102267],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.292386657836113, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_e5048631698e65dc479117cd02adb52b = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_5db00677fb66e94f87ca932987b08c90 = $(`<div id="html_5db00677fb66e94f87ca932987b08c90" style="width: 100.0%; height: 100.0%;">Lavis (IT) — pop 8,915</div>`)[0];
+                popup_e5048631698e65dc479117cd02adb52b.setContent(html_5db00677fb66e94f87ca932987b08c90);
+            
+        
+
+        circle_marker_c8281010395bf4c3001d32cbdef6f809.bindPopup(popup_e5048631698e65dc479117cd02adb52b)
+        ;
+
+        
+    
+    
+            var circle_marker_82b0a4c58698e1240dabfff1e052d978 = L.circleMarker(
+                [45.9053812, 12.1254301],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.292236137034138, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_a9b1fc171906f8f8e80310f8fdf60416 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_6838c6b2c2bd925402e39afea2353b79 = $(`<div id="html_6838c6b2c2bd925402e39afea2353b79" style="width: 100.0%; height: 100.0%;">Farra di Soligo (IT) — pop 8,913</div>`)[0];
+                popup_a9b1fc171906f8f8e80310f8fdf60416.setContent(html_6838c6b2c2bd925402e39afea2353b79);
+            
+        
+
+        circle_marker_82b0a4c58698e1240dabfff1e052d978.bindPopup(popup_a9b1fc171906f8f8e80310f8fdf60416)
+        ;
+
+        
+    
+    
+            var circle_marker_ae11bc2e3c954c4ab1d5c2d6793dae10 = L.circleMarker(
+                [45.76859, 13.00618],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.290956710217352, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_7f6de45a9cbdf1f1ac0f1a00faa39afd = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_ded4a5d58cd02ecd00b3aa53f3d8d70a = $(`<div id="html_ded4a5d58cd02ecd00b3aa53f3d8d70a" style="width: 100.0%; height: 100.0%;">Latisana (IT) — pop 8,896</div>`)[0];
+                popup_7f6de45a9cbdf1f1ac0f1a00faa39afd.setContent(html_ded4a5d58cd02ecd00b3aa53f3d8d70a);
+            
+        
+
+        circle_marker_ae11bc2e3c954c4ab1d5c2d6793dae10.bindPopup(popup_7f6de45a9cbdf1f1ac0f1a00faa39afd)
+        ;
+
+        
+    
+    
+            var circle_marker_2e7111349534434568da6f487b199744 = L.circleMarker(
+                [45.7776908, 12.9967006],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.290956710217352, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_01d93de8675c31500cdbbc961beffa13 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_50464c6ed9af4e971d74a26e6b906867 = $(`<div id="html_50464c6ed9af4e971d74a26e6b906867" style="width: 100.0%; height: 100.0%;">Latisana / Tisane (IT) — pop 8,896</div>`)[0];
+                popup_01d93de8675c31500cdbbc961beffa13.setContent(html_50464c6ed9af4e971d74a26e6b906867);
+            
+        
+
+        circle_marker_2e7111349534434568da6f487b199744.bindPopup(popup_01d93de8675c31500cdbbc961beffa13)
+        ;
+
+        
+    
+    
+            var circle_marker_7154131b8b3edb998f56c3269639e0f4 = L.circleMarker(
+                [45.5640412, 11.3748519],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.2825275453067615, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_9dccc8bf188ab7127b91aa4441d68d93 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_7dd2d0aa0636363e1d0935a1144d8a78 = $(`<div id="html_7dd2d0aa0636363e1d0935a1144d8a78" style="width: 100.0%; height: 100.0%;">Trissino (IT) — pop 8,784</div>`)[0];
+                popup_9dccc8bf188ab7127b91aa4441d68d93.setContent(html_7dd2d0aa0636363e1d0935a1144d8a78);
+            
+        
+
+        circle_marker_7154131b8b3edb998f56c3269639e0f4.bindPopup(popup_9dccc8bf188ab7127b91aa4441d68d93)
+        ;
+
+        
+    
+    
+            var circle_marker_d48282987fad653e915606bc869b45c8 = L.circleMarker(
+                [45.5335614, 11.9658789],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.280344993678126, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_b62bec517438fb3b4fbab3a5c7d74940 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_f027b151d92e430d485028083230e71a = $(`<div id="html_f027b151d92e430d485028083230e71a" style="width: 100.0%; height: 100.0%;">Borgoricco (IT) — pop 8,755</div>`)[0];
+                popup_b62bec517438fb3b4fbab3a5c7d74940.setContent(html_f027b151d92e430d485028083230e71a);
+            
+        
+
+        circle_marker_d48282987fad653e915606bc869b45c8.bindPopup(popup_b62bec517438fb3b4fbab3a5c7d74940)
+        ;
+
+        
+    
+    
+            var circle_marker_75b8b0fbf360db5fd338e4a58f60c880 = L.circleMarker(
+                [46.2156457, 13.2221061],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.277409838039617, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_2d5674d6508f9bc8c9b5f98f7658c42b = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_4cda544b00b9cc75872920d2e4c60fda = $(`<div id="html_4cda544b00b9cc75872920d2e4c60fda" style="width: 100.0%; height: 100.0%;">Tarcento / Tarcint (IT) — pop 8,716</div>`)[0];
+                popup_2d5674d6508f9bc8c9b5f98f7658c42b.setContent(html_4cda544b00b9cc75872920d2e4c60fda);
+            
+        
+
+        circle_marker_75b8b0fbf360db5fd338e4a58f60c880.bindPopup(popup_2d5674d6508f9bc8c9b5f98f7658c42b)
+        ;
+
+        
+    
+    
+            var circle_marker_f0f90d56ddd1b6044891b08788149ada = L.circleMarker(
+                [46.0485134, 13.1875972],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.276807754831718, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_8faba78456dc31f302305c3b534989e5 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_53f317f9a2418df7706286a89b6ae00c = $(`<div id="html_53f317f9a2418df7706286a89b6ae00c" style="width: 100.0%; height: 100.0%;">Pasian di Prato / Pasian di Prât (IT) — pop 8,708</div>`)[0];
+                popup_8faba78456dc31f302305c3b534989e5.setContent(html_53f317f9a2418df7706286a89b6ae00c);
+            
+        
+
+        circle_marker_f0f90d56ddd1b6044891b08788149ada.bindPopup(popup_8faba78456dc31f302305c3b534989e5)
+        ;
+
+        
+    
+    
+            var circle_marker_96437b9bad12f0feb0d7663d84864313 = L.circleMarker(
+                [45.82768, 10.10076],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.276581973628756, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_0308c9e6131e7d258680889717f0be71 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_838277dd317fc487a20994a2742914b5 = $(`<div id="html_838277dd317fc487a20994a2742914b5" style="width: 100.0%; height: 100.0%;">Costa Volpino (IT) — pop 8,705</div>`)[0];
+                popup_0308c9e6131e7d258680889717f0be71.setContent(html_838277dd317fc487a20994a2742914b5);
+            
+        
+
+        circle_marker_96437b9bad12f0feb0d7663d84864313.bindPopup(popup_0308c9e6131e7d258680889717f0be71)
+        ;
+
+        
+    
+    
+            var circle_marker_9c6ade7a11eeba6f2e63ad58ba84896e = L.circleMarker(
+                [45.76118, 12.82362],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.274474682401108, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_76c8a77b4339c08e88296f3bd7a3a944 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_6cb8cf6c4c8922deb2de889a05a94e6d = $(`<div id="html_6cb8cf6c4c8922deb2de889a05a94e6d" style="width: 100.0%; height: 100.0%;">Concordia Sagittaria (IT) — pop 8,677</div>`)[0];
+                popup_76c8a77b4339c08e88296f3bd7a3a944.setContent(html_6cb8cf6c4c8922deb2de889a05a94e6d);
+            
+        
+
+        circle_marker_9c6ade7a11eeba6f2e63ad58ba84896e.bindPopup(popup_76c8a77b4339c08e88296f3bd7a3a944)
+        ;
+
+        
+    
+    
+            var circle_marker_d8cd4b20ec138d5ef60d52c95f6bd8e6 = L.circleMarker(
+                [45.7081441, 11.5647668],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.274474682401108, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_7f96749afdb8941de8336a267da22421 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_bdd4d5d65df58edae4f630ed02d9436d = $(`<div id="html_bdd4d5d65df58edae4f630ed02d9436d" style="width: 100.0%; height: 100.0%;">Breganze (IT) — pop 8,677</div>`)[0];
+                popup_7f96749afdb8941de8336a267da22421.setContent(html_bdd4d5d65df58edae4f630ed02d9436d);
+            
+        
+
+        circle_marker_d8cd4b20ec138d5ef60d52c95f6bd8e6.bindPopup(popup_7f96749afdb8941de8336a267da22421)
+        ;
+
+        
+    
+    
+            var circle_marker_50e1ddce7311b43ad56a84a3120d64fb = L.circleMarker(
+                [45.6606078, 11.6029276],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.2709374435547, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_549f07f1727acb40cd0dd8712c9e376c = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_5089232326ffccde6c1f713399c81eae = $(`<div id="html_5089232326ffccde6c1f713399c81eae" style="width: 100.0%; height: 100.0%;">Sandrigo (IT) — pop 8,630</div>`)[0];
+                popup_549f07f1727acb40cd0dd8712c9e376c.setContent(html_5089232326ffccde6c1f713399c81eae);
+            
+        
+
+        circle_marker_50e1ddce7311b43ad56a84a3120d64fb.bindPopup(popup_549f07f1727acb40cd0dd8712c9e376c)
+        ;
+
+        
+    
+    
+            var circle_marker_165f5d44269dd89852f776e078b7d50a = L.circleMarker(
+                [45.4167857, 12.0306479],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.267776506713227, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_12b3f71a890d23c3aa85d75bf2f277b5 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_714e2b9e868a5ae8d164d265fefdb7af = $(`<div id="html_714e2b9e868a5ae8d164d265fefdb7af" style="width: 100.0%; height: 100.0%;">Fiesso d'Artico (IT) — pop 8,588</div>`)[0];
+                popup_12b3f71a890d23c3aa85d75bf2f277b5.setContent(html_714e2b9e868a5ae8d164d265fefdb7af);
+            
+        
+
+        circle_marker_165f5d44269dd89852f776e078b7d50a.bindPopup(popup_12b3f71a890d23c3aa85d75bf2f277b5)
+        ;
+
+        
+    
+    
+            var circle_marker_6a8b8f74a89fe7332da41f52d3fcd97c = L.circleMarker(
+                [45.7675549, 11.7593268],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.261755674634235, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_ac364295c5afd17c1d6d07957003bb2b = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_4da30da4b17cbe7e1e16dfbd1296fefd = $(`<div id="html_4da30da4b17cbe7e1e16dfbd1296fefd" style="width: 100.0%; height: 100.0%;">San Giuseppe (IT) — pop 8,508</div>`)[0];
+                popup_ac364295c5afd17c1d6d07957003bb2b.setContent(html_4da30da4b17cbe7e1e16dfbd1296fefd);
+            
+        
+
+        circle_marker_6a8b8f74a89fe7332da41f52d3fcd97c.bindPopup(popup_ac364295c5afd17c1d6d07957003bb2b)
+        ;
+
+        
+    
+    
+            var circle_marker_1410018649993d5a963acd834cd9c10f = L.circleMarker(
+                [47.46667, 9.75],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.2570895297730145, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_95fa0f4711288a05ac315c7e8aefe6cf = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_cd85ba0aee8472af33dc339179dfef35 = $(`<div id="html_cd85ba0aee8472af33dc339179dfef35" style="width: 100.0%; height: 100.0%;">Wolfurt (AT) — pop 8,446</div>`)[0];
+                popup_95fa0f4711288a05ac315c7e8aefe6cf.setContent(html_cd85ba0aee8472af33dc339179dfef35);
+            
+        
+
+        circle_marker_1410018649993d5a963acd834cd9c10f.bindPopup(popup_95fa0f4711288a05ac315c7e8aefe6cf)
+        ;
+
+        
+    
+    
+            var circle_marker_31397dfad3d9d709e1fe3c3657975e27 = L.circleMarker(
+                [45.9662544, 12.7715635],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.255885363357216, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_6fe95b3b6d2567272a32e165fa505ad5 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_f534a35006934ac2f75cf80f55ba4ab2 = $(`<div id="html_f534a35006934ac2f75cf80f55ba4ab2" style="width: 100.0%; height: 100.0%;">Zoppola / Sopula (IT) — pop 8,430</div>`)[0];
+                popup_6fe95b3b6d2567272a32e165fa505ad5.setContent(html_f534a35006934ac2f75cf80f55ba4ab2);
+            
+        
+
+        circle_marker_31397dfad3d9d709e1fe3c3657975e27.bindPopup(popup_6fe95b3b6d2567272a32e165fa505ad5)
+        ;
+
+        
+    
+    
+            var circle_marker_4e5a203bfd800a67db2a0cbedfb1a095 = L.circleMarker(
+                [45.9002, 12.11575],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.255509061352279, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_8bb5dc07e2a7c122f433f1b91ee250c7 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_04915ab11876263e4f043bbc33b36ef5 = $(`<div id="html_04915ab11876263e4f043bbc33b36ef5" style="width: 100.0%; height: 100.0%;">Col San Martino (IT) — pop 8,425</div>`)[0];
+                popup_8bb5dc07e2a7c122f433f1b91ee250c7.setContent(html_04915ab11876263e4f043bbc33b36ef5);
+            
+        
+
+        circle_marker_4e5a203bfd800a67db2a0cbedfb1a095.bindPopup(popup_8bb5dc07e2a7c122f433f1b91ee250c7)
+        ;
+
+        
+    
+    
+            var circle_marker_c42252a71110828e0ee0a3a7e3426743 = L.circleMarker(
+                [46.62368, 14.28892],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.255208019748329, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_70b78d381a8fcf9160e44d6aedaf6825 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_7367158d156e366bd31556aff2ae080d = $(`<div id="html_7367158d156e366bd31556aff2ae080d" style="width: 100.0%; height: 100.0%;">Villacher Vorstadt (AT) — pop 8,421</div>`)[0];
+                popup_70b78d381a8fcf9160e44d6aedaf6825.setContent(html_7367158d156e366bd31556aff2ae080d);
+            
+        
+
+        circle_marker_c42252a71110828e0ee0a3a7e3426743.bindPopup(popup_70b78d381a8fcf9160e44d6aedaf6825)
+        ;
+
+        
+    
+    
+            var circle_marker_6aa323ee1d7e0fad4e561884a5e651bc = L.circleMarker(
+                [46.56081, 13.87115],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.254079113733518, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_8c8b95e8362ea64be9c3a50867a2a22c = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_e5d77ccf8ee92fd67c62e6f41bfaf857 = $(`<div id="html_e5d77ccf8ee92fd67c62e6f41bfaf857" style="width: 100.0%; height: 100.0%;">Finkenstein am Faaker See (AT) — pop 8,406</div>`)[0];
+                popup_8c8b95e8362ea64be9c3a50867a2a22c.setContent(html_e5d77ccf8ee92fd67c62e6f41bfaf857);
+            
+        
+
+        circle_marker_6aa323ee1d7e0fad4e561884a5e651bc.bindPopup(popup_8c8b95e8362ea64be9c3a50867a2a22c)
+        ;
+
+        
+    
+    
+            var circle_marker_2a50eb8e0ced4d089df591c141edcc16 = L.circleMarker(
+                [45.6470275, 11.8304219],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.250015052080197, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_61886dcf42133f96107f9b97f017e251 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_b0875e655766a2a4d14b5395d98bf26b = $(`<div id="html_b0875e655766a2a4d14b5395d98bf26b" style="width: 100.0%; height: 100.0%;">Tombolo (IT) — pop 8,352</div>`)[0];
+                popup_61886dcf42133f96107f9b97f017e251.setContent(html_b0875e655766a2a4d14b5395d98bf26b);
+            
+        
+
+        circle_marker_2a50eb8e0ced4d089df591c141edcc16.bindPopup(popup_61886dcf42133f96107f9b97f017e251)
+        ;
+
+        
+    
+    
+            var circle_marker_3516ce8f1b193632ec84f9b0a098a059 = L.circleMarker(
+                [47.2867829, 11.4573834],
+                {"bubblingMouseEvents": true, "color": "blue", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "blue", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.250015052080197, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_de853fb058912e96dd3775ddcc5ffa77 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_0a24781bfc118d901c3dc963749deead = $(`<div id="html_0a24781bfc118d901c3dc963749deead" style="width: 100.0%; height: 100.0%;">Rum (DE) — pop 8,352</div>`)[0];
+                popup_de853fb058912e96dd3775ddcc5ffa77.setContent(html_0a24781bfc118d901c3dc963749deead);
+            
+        
+
+        circle_marker_3516ce8f1b193632ec84f9b0a098a059.bindPopup(popup_de853fb058912e96dd3775ddcc5ffa77)
+        ;
+
+        
+    
+    
+            var circle_marker_2b9ffba928e5046552a0130453a3abac = L.circleMarker(
+                [46.21482, 10.16335],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.249714010476247, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_471e5fb27fa738f0cf1edf9464b63924 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_8f84007b3b4023221ddcc6d717d7a3b8 = $(`<div id="html_8f84007b3b4023221ddcc6d717d7a3b8" style="width: 100.0%; height: 100.0%;">Tirano (IT) — pop 8,348</div>`)[0];
+                popup_471e5fb27fa738f0cf1edf9464b63924.setContent(html_8f84007b3b4023221ddcc6d717d7a3b8);
+            
+        
+
+        circle_marker_2b9ffba928e5046552a0130453a3abac.bindPopup(popup_471e5fb27fa738f0cf1edf9464b63924)
+        ;
+
+        
+    
+    
+            var circle_marker_286e2f2dd96cba94f8795d15ee71457c = L.circleMarker(
+                [45.7588257, 11.4301268],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.249563489674273, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_2271e0f2513f97f7d434e6cdef8b8fbf = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_70c4cf38c0ba1012ac77a61ffff87294 = $(`<div id="html_70c4cf38c0ba1012ac77a61ffff87294" style="width: 100.0%; height: 100.0%;">Piovene Rocchette (IT) — pop 8,346</div>`)[0];
+                popup_2271e0f2513f97f7d434e6cdef8b8fbf.setContent(html_70c4cf38c0ba1012ac77a61ffff87294);
+            
+        
+
+        circle_marker_286e2f2dd96cba94f8795d15ee71457c.bindPopup(popup_2271e0f2513f97f7d434e6cdef8b8fbf)
+        ;
+
+        
+    
+    
+            var circle_marker_87848896a52bea964aa49e055947887e = L.circleMarker(
+                [45.95091, 12.8425],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.2476067192486004, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_dd53b3a4e63f999477aaca860ecb36f6 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_389b4ab18bb44984bb516b9fa8c9c584 = $(`<div id="html_389b4ab18bb44984bb516b9fa8c9c584" style="width: 100.0%; height: 100.0%;">Casarsa della Delizia (IT) — pop 8,320</div>`)[0];
+                popup_dd53b3a4e63f999477aaca860ecb36f6.setContent(html_389b4ab18bb44984bb516b9fa8c9c584);
+            
+        
+
+        circle_marker_87848896a52bea964aa49e055947887e.bindPopup(popup_dd53b3a4e63f999477aaca860ecb36f6)
+        ;
+
+        
+    
+    
+            var circle_marker_b82a70a8e9b9363081bd31619526d492 = L.circleMarker(
+                [45.7161533, 12.4652271],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.246778854837738, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_0fdff2741d60ad940f9c2e5f0023dea8 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_8a06b76a2fa9811069ef7a5d94f26d57 = $(`<div id="html_8a06b76a2fa9811069ef7a5d94f26d57" style="width: 100.0%; height: 100.0%;">Ponte di Piave (IT) — pop 8,309</div>`)[0];
+                popup_0fdff2741d60ad940f9c2e5f0023dea8.setContent(html_8a06b76a2fa9811069ef7a5d94f26d57);
+            
+        
+
+        circle_marker_b82a70a8e9b9363081bd31619526d492.bindPopup(popup_0fdff2741d60ad940f9c2e5f0023dea8)
+        ;
+
+        
+    
+    
+            var circle_marker_156edc57e8e990480536a63dfb6acf9e = L.circleMarker(
+                [45.5280283, 11.4456338],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.2467035944367515, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_ec53ca1fe4ed26eeea3dfb2771955c98 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_db4fe8dd268e8acb540fef2e935d67f4 = $(`<div id="html_db4fe8dd268e8acb540fef2e935d67f4" style="width: 100.0%; height: 100.0%;">Sovizzo (IT) — pop 8,308</div>`)[0];
+                popup_ec53ca1fe4ed26eeea3dfb2771955c98.setContent(html_db4fe8dd268e8acb540fef2e935d67f4);
+            
+        
+
+        circle_marker_156edc57e8e990480536a63dfb6acf9e.bindPopup(popup_ec53ca1fe4ed26eeea3dfb2771955c98)
+        ;
+
+        
+    
+    
+            var circle_marker_68ed4eeef3cbeb551359973ef53b25f1 = L.circleMarker(
+                [45.98927, 12.54707],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.244822084412066, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_ad3adf1b8dfdb25028938b632dc4ebf8 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_2c781c1a360a42b2cd13d50dd2885a88 = $(`<div id="html_2c781c1a360a42b2cd13d50dd2885a88" style="width: 100.0%; height: 100.0%;">Vigonovo-Fontanafredda (IT) — pop 8,283</div>`)[0];
+                popup_ad3adf1b8dfdb25028938b632dc4ebf8.setContent(html_2c781c1a360a42b2cd13d50dd2885a88);
+            
+        
+
+        circle_marker_68ed4eeef3cbeb551359973ef53b25f1.bindPopup(popup_ad3adf1b8dfdb25028938b632dc4ebf8)
+        ;
+
+        
+    
+    
+            var circle_marker_cc5c5657792d9b8ee42cc7723aee58fc = L.circleMarker(
+                [46.07056, 12.59472],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.240456981154796, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_ec6b5cba6dce81fb513d86a16ca0edb5 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_d30bc9da3e5a60635618002dfbc3eb00 = $(`<div id="html_d30bc9da3e5a60635618002dfbc3eb00" style="width: 100.0%; height: 100.0%;">Aviano (IT) — pop 8,225</div>`)[0];
+                popup_ec6b5cba6dce81fb513d86a16ca0edb5.setContent(html_d30bc9da3e5a60635618002dfbc3eb00);
+            
+        
+
+        circle_marker_cc5c5657792d9b8ee42cc7723aee58fc.bindPopup(popup_ec6b5cba6dce81fb513d86a16ca0edb5)
+        ;
+
+        
+    
+    
+            var circle_marker_b9b994854993cbe2ce26f488a59a4514 = L.circleMarker(
+                [46.0685438, 12.5891138],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.240456981154796, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_b911adb67d709a0290ba9c60d184d178 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_ea97b5507f84ae4f425041f9241a90dd = $(`<div id="html_ea97b5507f84ae4f425041f9241a90dd" style="width: 100.0%; height: 100.0%;">Aviano / Davian - Pleif (IT) — pop 8,225</div>`)[0];
+                popup_b911adb67d709a0290ba9c60d184d178.setContent(html_ea97b5507f84ae4f425041f9241a90dd);
+            
+        
+
+        circle_marker_b9b994854993cbe2ce26f488a59a4514.bindPopup(popup_b911adb67d709a0290ba9c60d184d178)
+        ;
+
+        
+    
+    
+            var circle_marker_16097e02b612693884177b4e0a442160 = L.circleMarker(
+                [45.5804512, 12.3705001],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.23857547113011, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_d405dd24aceb12a5849850229a807383 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_00fa43512ae39f923c4fda8f16389550 = $(`<div id="html_00fa43512ae39f923c4fda8f16389550" style="width: 100.0%; height: 100.0%;">Quarto d'Altino (IT) — pop 8,200</div>`)[0];
+                popup_d405dd24aceb12a5849850229a807383.setContent(html_00fa43512ae39f923c4fda8f16389550);
+            
+        
+
+        circle_marker_16097e02b612693884177b4e0a442160.bindPopup(popup_d405dd24aceb12a5849850229a807383)
+        ;
+
+        
+    
+    
+            var circle_marker_8e03ab6773d082bd74a01ab156bbf2af = L.circleMarker(
+                [46.61275, 13.84638],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.237747606719249, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_c134573858d925b77e08e81ebcf337df = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_cc2fdd81cb72afcedbcb50ef66d7ee3d = $(`<div id="html_cc2fdd81cb72afcedbcb50ef66d7ee3d" style="width: 100.0%; height: 100.0%;">Villach-Innere Stadt (AT) — pop 8,189</div>`)[0];
+                popup_c134573858d925b77e08e81ebcf337df.setContent(html_cc2fdd81cb72afcedbcb50ef66d7ee3d);
+            
+        
+
+        circle_marker_8e03ab6773d082bd74a01ab156bbf2af.bindPopup(popup_c134573858d925b77e08e81ebcf337df)
+        ;
+
+        
+    
+    
+            var circle_marker_7defc98fbceaa94923299bccb88f4f48 = L.circleMarker(
+                [45.6376293, 11.7521976],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.236317659100488, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_ae6ae6db79878771e4a5389088f235de = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_516920e1c2d046650632fd575401e4cc = $(`<div id="html_516920e1c2d046650632fd575401e4cc" style="width: 100.0%; height: 100.0%;">Fontaniva (IT) — pop 8,170</div>`)[0];
+                popup_ae6ae6db79878771e4a5389088f235de.setContent(html_516920e1c2d046650632fd575401e4cc);
+            
+        
+
+        circle_marker_7defc98fbceaa94923299bccb88f4f48.bindPopup(popup_ae6ae6db79878771e4a5389088f235de)
+        ;
+
+        
+    
+    
+            var circle_marker_1582db58f347fcdf78b284b0401493e5 = L.circleMarker(
+                [47.2741, 11.23961],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.235715575892589, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_335a0402d07c66b97c254ad4462f78e3 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_1a25f608863e8636474d4009e62ee671 = $(`<div id="html_1a25f608863e8636474d4009e62ee671" style="width: 100.0%; height: 100.0%;">Zirl (AT) — pop 8,162</div>`)[0];
+                popup_335a0402d07c66b97c254ad4462f78e3.setContent(html_1a25f608863e8636474d4009e62ee671);
+            
+        
+
+        circle_marker_1582db58f347fcdf78b284b0401493e5.bindPopup(popup_335a0402d07c66b97c254ad4462f78e3)
+        ;
+
+        
+    
+    
+            var circle_marker_12b3f9ad79bcc88ae7118c28e513cbb6 = L.circleMarker(
+                [45.9559372, 12.8426929],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.2336835450659285, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_99ebd1f007b41707fcde123faa251602 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_8fbd016ad1eb1ee53517a3289b83ba20 = $(`<div id="html_8fbd016ad1eb1ee53517a3289b83ba20" style="width: 100.0%; height: 100.0%;">Casarsa della Delizia / Cjasarsa (IT) — pop 8,135</div>`)[0];
+                popup_99ebd1f007b41707fcde123faa251602.setContent(html_8fbd016ad1eb1ee53517a3289b83ba20);
+            
+        
+
+        circle_marker_12b3f9ad79bcc88ae7118c28e513cbb6.bindPopup(popup_99ebd1f007b41707fcde123faa251602)
+        ;
+
+        
+    
+    
+            var circle_marker_2b93d7fde4a92dfde8402287d87dcaee = L.circleMarker(
+                [45.9035103, 12.5259887],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.231952555843217, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_c5779d0cbdf38ba42737d1c68c93fdc9 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_4c543f54247c96de8d6553f92190514c = $(`<div id="html_4c543f54247c96de8d6553f92190514c" style="width: 100.0%; height: 100.0%;">Brugnera / Brugnere (IT) — pop 8,112</div>`)[0];
+                popup_c5779d0cbdf38ba42737d1c68c93fdc9.setContent(html_4c543f54247c96de8d6553f92190514c);
+            
+        
+
+        circle_marker_2b93d7fde4a92dfde8402287d87dcaee.bindPopup(popup_c5779d0cbdf38ba42737d1c68c93fdc9)
+        ;
+
+        
+    
+    
+            var circle_marker_d558f9f74583e7a28c3ea1e9a3495be0 = L.circleMarker(
+                [45.7052727, 11.7997866],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.231199951833343, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_8a7859ac60759fb54e9c364adedc5b1b = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_55da52c4e078b57e4c93608bf5a7ca2a = $(`<div id="html_55da52c4e078b57e4c93608bf5a7ca2a" style="width: 100.0%; height: 100.0%;">Rossano Veneto (IT) — pop 8,102</div>`)[0];
+                popup_8a7859ac60759fb54e9c364adedc5b1b.setContent(html_55da52c4e078b57e4c93608bf5a7ca2a);
+            
+        
+
+        circle_marker_d558f9f74583e7a28c3ea1e9a3495be0.bindPopup(popup_8a7859ac60759fb54e9c364adedc5b1b)
+        ;
+
+        
+    
+    
+            var circle_marker_96862c426c862810b814812aeb9d4136 = L.circleMarker(
+                [46.39996, 13.02051],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.229393702209645, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_bf34cce92b4b2f5129301d478849d2f9 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_7fb6b643cc69b7f2e4fb457a533d3b0b = $(`<div id="html_7fb6b643cc69b7f2e4fb457a533d3b0b" style="width: 100.0%; height: 100.0%;">Tolmezzo (IT) — pop 8,078</div>`)[0];
+                popup_bf34cce92b4b2f5129301d478849d2f9.setContent(html_7fb6b643cc69b7f2e4fb457a533d3b0b);
+            
+        
+
+        circle_marker_96862c426c862810b814812aeb9d4136.bindPopup(popup_bf34cce92b4b2f5129301d478849d2f9)
+        ;
+
+        
+    
+    
+            var circle_marker_72abece07b7439e72db3a71f7ddbb257 = L.circleMarker(
+                [45.4330543, 12.1233467],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.226082244566199, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_e1e289f14e1c1d3b2d1d8461004b46d1 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_4e1f7e8265ad5d1cee90d5429f7c03a2 = $(`<div id="html_4e1f7e8265ad5d1cee90d5429f7c03a2" style="width: 100.0%; height: 100.0%;">Mira Taglio (IT) — pop 8,034</div>`)[0];
+                popup_e1e289f14e1c1d3b2d1d8461004b46d1.setContent(html_4e1f7e8265ad5d1cee90d5429f7c03a2);
+            
+        
+
+        circle_marker_72abece07b7439e72db3a71f7ddbb257.bindPopup(popup_e1e289f14e1c1d3b2d1d8461004b46d1)
+        ;
+
+        
+    
+    
+            var circle_marker_76c555473e3da3c54fd55566b51689ae = L.circleMarker(
+                [45.88663, 9.94646],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.225931723764225, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_a1ef96a891d208c4b33137b3bba6c660 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_7adde3850354c00809b932e69dfd7a24 = $(`<div id="html_7adde3850354c00809b932e69dfd7a24" style="width: 100.0%; height: 100.0%;">Clusone (IT) — pop 8,032</div>`)[0];
+                popup_a1ef96a891d208c4b33137b3bba6c660.setContent(html_7adde3850354c00809b932e69dfd7a24);
+            
+        
+
+        circle_marker_76c555473e3da3c54fd55566b51689ae.bindPopup(popup_a1ef96a891d208c4b33137b3bba6c660)
+        ;
+
+        
+    
+    
+            var circle_marker_41c0f7b737ed5e0b87450070ed7e3ff7 = L.circleMarker(
+                [45.7859102, 12.0010378],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.224802817749413, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_b92a922606742ce657b8866576fee653 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_95ee2f0b93cc2430dd15821c9e1dc192 = $(`<div id="html_95ee2f0b93cc2430dd15821c9e1dc192" style="width: 100.0%; height: 100.0%;">Caerano di San Marco (IT) — pop 8,017</div>`)[0];
+                popup_b92a922606742ce657b8866576fee653.setContent(html_95ee2f0b93cc2430dd15821c9e1dc192);
+            
+        
+
+        circle_marker_41c0f7b737ed5e0b87450070ed7e3ff7.bindPopup(popup_b92a922606742ce657b8866576fee653)
+        ;
+
+        
+    
+    
+            var circle_marker_31f7903d8433f5ddb5031a8822daf127 = L.circleMarker(
+                [46.1600501, 13.0105965],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.2245017761454635, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_092f86d65fa4c3a7fb318ea5babc91d0 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_a31fd9807ab6059a03162b795455aa2f = $(`<div id="html_a31fd9807ab6059a03162b795455aa2f" style="width: 100.0%; height: 100.0%;">San Daniele del Friuli / San Denêl (IT) — pop 8,013</div>`)[0];
+                popup_092f86d65fa4c3a7fb318ea5babc91d0.setContent(html_a31fd9807ab6059a03162b795455aa2f);
+            
+        
+
+        circle_marker_31f7903d8433f5ddb5031a8822daf127.bindPopup(popup_092f86d65fa4c3a7fb318ea5babc91d0)
+        ;
+
+        
+    
+    
+            var circle_marker_206a29e888c0825367da2086e1303b86 = L.circleMarker(
+                [45.6878, 13.78861],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.224200734541514, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_b6f1001bc15c7e50c299ba8cfec50603 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_42711649fd9e91c13657b2c336541f09 = $(`<div id="html_42711649fd9e91c13657b2c336541f09" style="width: 100.0%; height: 100.0%;">Villa Opicina (IT) — pop 8,009</div>`)[0];
+                popup_b6f1001bc15c7e50c299ba8cfec50603.setContent(html_42711649fd9e91c13657b2c336541f09);
+            
+        
+
+        circle_marker_206a29e888c0825367da2086e1303b86.bindPopup(popup_b6f1001bc15c7e50c299ba8cfec50603)
+        ;
+
+        
+    
+    
+            var circle_marker_930b18d5e80e5f6d504ec3072f50490c = L.circleMarker(
+                [47.4422, 11.26187],
+                {"bubblingMouseEvents": true, "color": "blue", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "blue", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.223222349328677, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_d30d11f96e3bc167bcf88e821f300daf = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_5504301e668a5ccb6bb610d469ed54e5 = $(`<div id="html_5504301e668a5ccb6bb610d469ed54e5" style="width: 100.0%; height: 100.0%;">Mittenwald (DE) — pop 7,996</div>`)[0];
+                popup_d30d11f96e3bc167bcf88e821f300daf.setContent(html_5504301e668a5ccb6bb610d469ed54e5);
+            
+        
+
+        circle_marker_930b18d5e80e5f6d504ec3072f50490c.bindPopup(popup_d30d11f96e3bc167bcf88e821f300daf)
+        ;
+
+        
+    
+    
+            var circle_marker_5c266a52e0df076aef9d68a505dac19a = L.circleMarker(
+                [47.45934, 9.6405],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.22314708892769, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_6487cd49210fade71e7fb91b819021d5 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_f809d978f3af0176bc8958ee25bf5431 = $(`<div id="html_f809d978f3af0176bc8958ee25bf5431" style="width: 100.0%; height: 100.0%;">Höchst (AT) — pop 7,995</div>`)[0];
+                popup_6487cd49210fade71e7fb91b819021d5.setContent(html_f809d978f3af0176bc8958ee25bf5431);
+            
+        
+
+        circle_marker_5c266a52e0df076aef9d68a505dac19a.bindPopup(popup_6487cd49210fade71e7fb91b819021d5)
+        ;
+
+        
+    
+    
+            var circle_marker_21cfef90f0a1f0bb48dc919cb2d5ecd0 = L.circleMarker(
+                [45.4743763, 11.8449327],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.219910891685231, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_469bedbfe1ab3366397f1eeb284902c3 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_36201797f14313cc68d7ebd51bd41886 = $(`<div id="html_36201797f14313cc68d7ebd51bd41886" style="width: 100.0%; height: 100.0%;">Limena (IT) — pop 7,952</div>`)[0];
+                popup_469bedbfe1ab3366397f1eeb284902c3.setContent(html_36201797f14313cc68d7ebd51bd41886);
+            
+        
+
+        circle_marker_21cfef90f0a1f0bb48dc919cb2d5ecd0.bindPopup(popup_469bedbfe1ab3366397f1eeb284902c3)
+        ;
+
+        
+    
+    
+            var circle_marker_b559f5af26ef061fe4ac2866d3b1dbb6 = L.circleMarker(
+                [46.0091259, 11.3017774],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.2171262568486965, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_1ee493831c663e93b6b4456313e34ce3 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_8c155b8505c4f57d22406d6a2f286a30 = $(`<div id="html_8c155b8505c4f57d22406d6a2f286a30" style="width: 100.0%; height: 100.0%;">Levico Terme (IT) — pop 7,915</div>`)[0];
+                popup_1ee493831c663e93b6b4456313e34ce3.setContent(html_8c155b8505c4f57d22406d6a2f286a30);
+            
+        
+
+        circle_marker_b559f5af26ef061fe4ac2866d3b1dbb6.bindPopup(popup_1ee493831c663e93b6b4456313e34ce3)
+        ;
+
+        
+    
+    
+            var circle_marker_2dc62c8849c063e4d48a542a18cb6d19 = L.circleMarker(
+                [46.18083, 12.28333],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.216975736046722, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_281e1d794fbb4f148de215328b7db943 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_e394fb899648d5ead0d766c50945b589 = $(`<div id="html_e394fb899648d5ead0d766c50945b589" style="width: 100.0%; height: 100.0%;">Ponte nelle Alpi (IT) — pop 7,913</div>`)[0];
+                popup_281e1d794fbb4f148de215328b7db943.setContent(html_e394fb899648d5ead0d766c50945b589);
+            
+        
+
+        circle_marker_2dc62c8849c063e4d48a542a18cb6d19.bindPopup(popup_281e1d794fbb4f148de215328b7db943)
+        ;
+
+        
+    
+    
+            var circle_marker_2b08fb5d3bb2a68a7739445f0b450525 = L.circleMarker(
+                [47.5822, 10.54962],
+                {"bubblingMouseEvents": true, "color": "blue", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "blue", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.215244746824011, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_f554f6d4ce11271a7a2056c5a9a9454e = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_a5cec4521fc4f6e76b6368c937fc605c = $(`<div id="html_a5cec4521fc4f6e76b6368c937fc605c" style="width: 100.0%; height: 100.0%;">Pfronten (DE) — pop 7,890</div>`)[0];
+                popup_f554f6d4ce11271a7a2056c5a9a9454e.setContent(html_a5cec4521fc4f6e76b6368c937fc605c);
+            
+        
+
+        circle_marker_2b08fb5d3bb2a68a7739445f0b450525.bindPopup(popup_f554f6d4ce11271a7a2056c5a9a9454e)
+        ;
+
+        
+    
+    
+            var circle_marker_76ce01f382464289a527780f2700a32f = L.circleMarker(
+                [47.29419, 11.5907],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.214567403215124, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_b1bd6de8d70d115ff3a62f4d60c7b3e7 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_fdf285f5da552c3c922f5dc9190c9b35 = $(`<div id="html_fdf285f5da552c3c922f5dc9190c9b35" style="width: 100.0%; height: 100.0%;">Wattens (AT) — pop 7,881</div>`)[0];
+                popup_b1bd6de8d70d115ff3a62f4d60c7b3e7.setContent(html_fdf285f5da552c3c922f5dc9190c9b35);
+            
+        
+
+        circle_marker_76ce01f382464289a527780f2700a32f.bindPopup(popup_b1bd6de8d70d115ff3a62f4d60c7b3e7)
+        ;
+
+        
+    
+    
+            var circle_marker_76f06cce95afab8d319b869d8d69d4ca = L.circleMarker(
+                [47.13988, 10.56593],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.202826780661088, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_496839e57b9b1db51819684071bdd9d4 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_c2eb5eafefe1c32e0331ab46a2bf2083 = $(`<div id="html_c2eb5eafefe1c32e0331ab46a2bf2083" style="width: 100.0%; height: 100.0%;">Landeck (AT) — pop 7,725</div>`)[0];
+                popup_496839e57b9b1db51819684071bdd9d4.setContent(html_c2eb5eafefe1c32e0331ab46a2bf2083);
+            
+        
+
+        circle_marker_76f06cce95afab8d319b869d8d69d4ca.bindPopup(popup_496839e57b9b1db51819684071bdd9d4)
+        ;
+
+        
+    
+    
+            var circle_marker_324c086fc4a0aa2cc13a8af3bd56ca6b = L.circleMarker(
+                [45.75571, 6.41503],
+                {"bubblingMouseEvents": true, "color": "green", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "green", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.201171051839364, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_112bdb132653f71f73e2fcf2b26e41af = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_fb34b7a040918a0fbdd9be3b84a7c7e9 = $(`<div id="html_fb34b7a040918a0fbdd9be3b84a7c7e9" style="width: 100.0%; height: 100.0%;">Ugine (FR) — pop 7,703</div>`)[0];
+                popup_112bdb132653f71f73e2fcf2b26e41af.setContent(html_fb34b7a040918a0fbdd9be3b84a7c7e9);
+            
+        
+
+        circle_marker_324c086fc4a0aa2cc13a8af3bd56ca6b.bindPopup(popup_112bdb132653f71f73e2fcf2b26e41af)
+        ;
+
+        
+    
+    
+            var circle_marker_d82ae01377575fe0ce37d18e9655e6b5 = L.circleMarker(
+                [45.4847054, 12.1888093],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.19868745860678, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_3d39a96c2239c50df57c00cc9209185a = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_d779969e420b81d0349ff64465406b41 = $(`<div id="html_d779969e420b81d0349ff64465406b41" style="width: 100.0%; height: 100.0%;">Chirignago (IT) — pop 7,670</div>`)[0];
+                popup_3d39a96c2239c50df57c00cc9209185a.setContent(html_d779969e420b81d0349ff64465406b41);
+            
+        
+
+        circle_marker_d82ae01377575fe0ce37d18e9655e6b5.bindPopup(popup_3d39a96c2239c50df57c00cc9209185a)
+        ;
+
+        
+    
+    
+            var circle_marker_c5f8f6f3ca6883fdb10ceb848686953f = L.circleMarker(
+                [45.7789522, 11.8012715],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.197784333794931, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_9d2a9c52682b18353d0418939258dc17 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_69bae45c383508d0d4c8f8dd92d074eb = $(`<div id="html_69bae45c383508d0d4c8f8dd92d074eb" style="width: 100.0%; height: 100.0%;">Mussolente (IT) — pop 7,658</div>`)[0];
+                popup_9d2a9c52682b18353d0418939258dc17.setContent(html_69bae45c383508d0d4c8f8dd92d074eb);
+            
+        
+
+        circle_marker_c5f8f6f3ca6883fdb10ceb848686953f.bindPopup(popup_9d2a9c52682b18353d0418939258dc17)
+        ;
+
+        
+    
+    
+            var circle_marker_759db192781b6f12f4969828bc9883de = L.circleMarker(
+                [45.5855421, 11.4877438],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.195978084171233, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_289834ccdc133abb3a6991a0601cb80b = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_16103daf6327151febb153fd20e7b2f7 = $(`<div id="html_16103daf6327151febb153fd20e7b2f7" style="width: 100.0%; height: 100.0%;">Costabissara (IT) — pop 7,634</div>`)[0];
+                popup_289834ccdc133abb3a6991a0601cb80b.setContent(html_16103daf6327151febb153fd20e7b2f7);
+            
+        
+
+        circle_marker_759db192781b6f12f4969828bc9883de.bindPopup(popup_289834ccdc133abb3a6991a0601cb80b)
+        ;
+
+        
+    
+    
+            var circle_marker_bedcbd299f6007250eb13df2cdc0dd4b = L.circleMarker(
+                [45.594524, 11.9446117],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.193268709735685, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_80355c4733272b810572a0455dc3af68 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_d7ee1a078f06b46cafa8a444c8658fee = $(`<div id="html_d7ee1a078f06b46cafa8a444c8658fee" style="width: 100.0%; height: 100.0%;">Loreggia (IT) — pop 7,598</div>`)[0];
+                popup_80355c4733272b810572a0455dc3af68.setContent(html_d7ee1a078f06b46cafa8a444c8658fee);
+            
+        
+
+        circle_marker_bedcbd299f6007250eb13df2cdc0dd4b.bindPopup(popup_80355c4733272b810572a0455dc3af68)
+        ;
+
+        
+    
+    
+            var circle_marker_b1ef8fefa45766be9cfa9799dfbb3605 = L.circleMarker(
+                [45.7468537, 6.2934242],
+                {"bubblingMouseEvents": true, "color": "green", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "green", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.191989282918899, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_fd81b5617ccddfb788afa2f730edfc43 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_6482681dc85c066c3f0b94f0dd055f5e = $(`<div id="html_6482681dc85c066c3f0b94f0dd055f5e" style="width: 100.0%; height: 100.0%;">Faverges (FR) — pop 7,581</div>`)[0];
+                popup_fd81b5617ccddfb788afa2f730edfc43.setContent(html_6482681dc85c066c3f0b94f0dd055f5e);
+            
+        
+
+        circle_marker_b1ef8fefa45766be9cfa9799dfbb3605.bindPopup(popup_fd81b5617ccddfb788afa2f730edfc43)
+        ;
+
+        
+    
+    
+            var circle_marker_748cdb3b04c80e1889e826e9368858eb = L.circleMarker(
+                [47.2935786, 11.5907326],
+                {"bubblingMouseEvents": true, "color": "blue", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "blue", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.186118971641881, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_b44dd6f3e8ce65023dd8e5ad0b480b33 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_f6e600984d998366af0c401cca6f0399 = $(`<div id="html_f6e600984d998366af0c401cca6f0399" style="width: 100.0%; height: 100.0%;">Wattens (DE) — pop 7,503</div>`)[0];
+                popup_b44dd6f3e8ce65023dd8e5ad0b480b33.setContent(html_f6e600984d998366af0c401cca6f0399);
+            
+        
+
+        circle_marker_748cdb3b04c80e1889e826e9368858eb.bindPopup(popup_b44dd6f3e8ce65023dd8e5ad0b480b33)
+        ;
+
+        
+    
+    
+            var circle_marker_11838d39c0405444302ff54bbbb86b78 = L.circleMarker(
+                [45.4100182, 12.0050219],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.183635378409297, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_c56757f2b77d902d7814210e0ca53e4b = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_1afd66d25998af417a3051c26e94e17c = $(`<div id="html_1afd66d25998af417a3051c26e94e17c" style="width: 100.0%; height: 100.0%;">Stra (IT) — pop 7,470</div>`)[0];
+                popup_c56757f2b77d902d7814210e0ca53e4b.setContent(html_1afd66d25998af417a3051c26e94e17c);
+            
+        
+
+        circle_marker_11838d39c0405444302ff54bbbb86b78.bindPopup(popup_c56757f2b77d902d7814210e0ca53e4b)
+        ;
+
+        
+    
+    
+            var circle_marker_62822bbab5f6d9148671557d0e03c386 = L.circleMarker(
+                [45.8695205, 11.9695508],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.182205430790535, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_fc2adde0ba186a392cd242e7908db203 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_dba39990bcbacf0d60419ff2c9d70db0 = $(`<div id="html_dba39990bcbacf0d60419ff2c9d70db0" style="width: 100.0%; height: 100.0%;">Pederobba (IT) — pop 7,451</div>`)[0];
+                popup_fc2adde0ba186a392cd242e7908db203.setContent(html_dba39990bcbacf0d60419ff2c9d70db0);
+            
+        
+
+        circle_marker_62822bbab5f6d9148671557d0e03c386.bindPopup(popup_fc2adde0ba186a392cd242e7908db203)
+        ;
+
+        
+    
+    
+            var circle_marker_4905e6234616c55aebbe63e8ffef1cbe = L.circleMarker(
+                [46.6, 14.31667],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.181528087181649, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_a5f121ea1b4e4afcdb8ed1d7018c26b1 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_b43a53167fc2c1478f7312ee0243fe07 = $(`<div id="html_b43a53167fc2c1478f7312ee0243fe07" style="width: 100.0%; height: 100.0%;">Sankt Ruprecht (AT) — pop 7,442</div>`)[0];
+                popup_a5f121ea1b4e4afcdb8ed1d7018c26b1.setContent(html_b43a53167fc2c1478f7312ee0243fe07);
+            
+        
+
+        circle_marker_4905e6234616c55aebbe63e8ffef1cbe.bindPopup(popup_a5f121ea1b4e4afcdb8ed1d7018c26b1)
+        ;
+
+        
+    
+    
+            var circle_marker_b645897d53a98b3ee2e8b30be8a58e81 = L.circleMarker(
+                [45.8497541, 12.6265087],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.1800228791619, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_0768778cfa0e9c4feba9cd8ea2081014 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_53549e8cea3e9f8de01e850caa7700b0 = $(`<div id="html_53549e8cea3e9f8de01e850caa7700b0" style="width: 100.0%; height: 100.0%;">Pasiano di Pordenone / Pasian di Pordenon (IT) — pop 7,422</div>`)[0];
+                popup_0768778cfa0e9c4feba9cd8ea2081014.setContent(html_53549e8cea3e9f8de01e850caa7700b0);
+            
+        
+
+        circle_marker_b645897d53a98b3ee2e8b30be8a58e81.bindPopup(popup_0768778cfa0e9c4feba9cd8ea2081014)
+        ;
+
+        
+    
+    
+            var circle_marker_a18632273b1b29ee9dd7eb0deb6f1b95 = L.circleMarker(
+                [45.7790023, 11.8405331],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.177689806731291, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_c62aab0c8b3bd17ae878e4c3a57a7146 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_bb28fa578400e131e546c5c71f3d7c79 = $(`<div id="html_bb28fa578400e131e546c5c71f3d7c79" style="width: 100.0%; height: 100.0%;">San Zenone degli Ezzelini (IT) — pop 7,391</div>`)[0];
+                popup_c62aab0c8b3bd17ae878e4c3a57a7146.setContent(html_bb28fa578400e131e546c5c71f3d7c79);
+            
+        
+
+        circle_marker_a18632273b1b29ee9dd7eb0deb6f1b95.bindPopup(popup_c62aab0c8b3bd17ae878e4c3a57a7146)
+        ;
+
+        
+    
+    
+            var circle_marker_71a67e94401e983f0b821f8a836735cf = L.circleMarker(
+                [45.41954, 12.03378],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.1762598591125295, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_33ced961758fa0937944229255ee8d79 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_c8462e8421136d08fe98954de3da23eb = $(`<div id="html_c8462e8421136d08fe98954de3da23eb" style="width: 100.0%; height: 100.0%;">Fiesso (IT) — pop 7,372</div>`)[0];
+                popup_33ced961758fa0937944229255ee8d79.setContent(html_c8462e8421136d08fe98954de3da23eb);
+            
+        
+
+        circle_marker_71a67e94401e983f0b821f8a836735cf.bindPopup(popup_33ced961758fa0937944229255ee8d79)
+        ;
+
+        
+    
+    
+            var circle_marker_bb0e8c496907005f9e6ada81ef8f824a = L.circleMarker(
+                [45.5222551, 11.832017],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.1727226202661205, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_c9069cd2ec88e07fcb766aa4dcdd2432 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_d3f59477d8c6d18b83a4dbe9d402f9c1 = $(`<div id="html_d3f59477d8c6d18b83a4dbe9d402f9c1" style="width: 100.0%; height: 100.0%;">Curtarolo (IT) — pop 7,325</div>`)[0];
+                popup_c9069cd2ec88e07fcb766aa4dcdd2432.setContent(html_d3f59477d8c6d18b83a4dbe9d402f9c1);
+            
+        
+
+        circle_marker_bb0e8c496907005f9e6ada81ef8f824a.bindPopup(popup_c9069cd2ec88e07fcb766aa4dcdd2432)
+        ;
+
+        
+    
+    
+            var circle_marker_54a9ca04d90b492e31899f9d898b5a67 = L.circleMarker(
+                [45.8320236, 13.2111453],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.171894755855259, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_0adc11e81b4d7d3bdbe6770ebb8c2f52 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_e4d04f6a62b93c8c9102da19aecaae99 = $(`<div id="html_e4d04f6a62b93c8c9102da19aecaae99" style="width: 100.0%; height: 100.0%;">San Giorgio di Nogaro / San Zorç di Noiâr (IT) — pop 7,314</div>`)[0];
+                popup_0adc11e81b4d7d3bdbe6770ebb8c2f52.setContent(html_e4d04f6a62b93c8c9102da19aecaae99);
+            
+        
+
+        circle_marker_54a9ca04d90b492e31899f9d898b5a67.bindPopup(popup_0adc11e81b4d7d3bdbe6770ebb8c2f52)
+        ;
+
+        
+    
+    
+            var circle_marker_a479d36b6f96e12d72c29769a2d58322 = L.circleMarker(
+                [46.1605618, 13.2125359],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.1712174122463725, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_1e8866e39c09ed52e0c3b0a9a7547952 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_5ce21b900b91eebd168fdeb1bbed1e72 = $(`<div id="html_5ce21b900b91eebd168fdeb1bbed1e72" style="width: 100.0%; height: 100.0%;">Tricesimo / Tresesin (IT) — pop 7,305</div>`)[0];
+                popup_1e8866e39c09ed52e0c3b0a9a7547952.setContent(html_5ce21b900b91eebd168fdeb1bbed1e72);
+            
+        
+
+        circle_marker_a479d36b6f96e12d72c29769a2d58322.bindPopup(popup_1e8866e39c09ed52e0c3b0a9a7547952)
+        ;
+
+        
+    
+    
+            var circle_marker_159909050f31cd37d45f20d373839990 = L.circleMarker(
+                [46.0195268, 13.1601994],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.16662652778614, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_389fd67ba246d84edf7d43381b191f08 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_8966a3188a70be4407209f4a321b6bb3 = $(`<div id="html_8966a3188a70be4407209f4a321b6bb3" style="width: 100.0%; height: 100.0%;">Campoformido / Cjampfuarmit (IT) — pop 7,244</div>`)[0];
+                popup_389fd67ba246d84edf7d43381b191f08.setContent(html_8966a3188a70be4407209f4a321b6bb3);
+            
+        
+
+        circle_marker_159909050f31cd37d45f20d373839990.bindPopup(popup_389fd67ba246d84edf7d43381b191f08)
+        ;
+
+        
+    
+    
+            var circle_marker_400aa8871493df26ca1f799b62d4fa88 = L.circleMarker(
+                [46.32063, 9.39816],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.166250225781203, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_308c51f10b2a7b0b50c7b06e390a21f4 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_6ed860788dbf8a52d92770e350656530 = $(`<div id="html_6ed860788dbf8a52d92770e350656530" style="width: 100.0%; height: 100.0%;">Chiavenna (IT) — pop 7,239</div>`)[0];
+                popup_308c51f10b2a7b0b50c7b06e390a21f4.setContent(html_6ed860788dbf8a52d92770e350656530);
+            
+        
+
+        circle_marker_400aa8871493df26ca1f799b62d4fa88.bindPopup(popup_308c51f10b2a7b0b50c7b06e390a21f4)
+        ;
+
+        
+    
+    
+            var circle_marker_f468eea194cc69709beffab7ed115fc9 = L.circleMarker(
+                [45.563698, 11.906406],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.1647450177614544, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_451da897bf60615b89144f867d3b4e81 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_e5b197911473fb044b15d9f5ab4f093f = $(`<div id="html_e5b197911473fb044b15d9f5ab4f093f" style="width: 100.0%; height: 100.0%;">Santa Giustina in Colle (IT) — pop 7,219</div>`)[0];
+                popup_451da897bf60615b89144f867d3b4e81.setContent(html_e5b197911473fb044b15d9f5ab4f093f);
+            
+        
+
+        circle_marker_f468eea194cc69709beffab7ed115fc9.bindPopup(popup_451da897bf60615b89144f867d3b4e81)
+        ;
+
+        
+    
+    
+            var circle_marker_fd6ad4cec27c8558cebef33744c4846e = L.circleMarker(
+                [46.13205, 9.37714],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.163616111746643, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_1aa4953545b68cb247b1c893e3d11b4b = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_f133fff2132786f46dd902f3ec4d46bf = $(`<div id="html_f133fff2132786f46dd902f3ec4d46bf" style="width: 100.0%; height: 100.0%;">Colico (IT) — pop 7,204</div>`)[0];
+                popup_1aa4953545b68cb247b1c893e3d11b4b.setContent(html_f133fff2132786f46dd902f3ec4d46bf);
+            
+        
+
+        circle_marker_fd6ad4cec27c8558cebef33744c4846e.bindPopup(popup_1aa4953545b68cb247b1c893e3d11b4b)
+        ;
+
+        
+    
+    
+            var circle_marker_6f9e795754f948ae30b92a84e3a0319d = L.circleMarker(
+                [47.55568, 10.02245],
+                {"bubblingMouseEvents": true, "color": "blue", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "blue", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.16256246613282, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_6f2167c11e96202b082aba9a383f2e6a = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_62f6ed3dcdc3b3eddd6d76a5d37ef31d = $(`<div id="html_62f6ed3dcdc3b3eddd6d76a5d37ef31d" style="width: 100.0%; height: 100.0%;">Oberstaufen (DE) — pop 7,190</div>`)[0];
+                popup_6f2167c11e96202b082aba9a383f2e6a.setContent(html_62f6ed3dcdc3b3eddd6d76a5d37ef31d);
+            
+        
+
+        circle_marker_6f9e795754f948ae30b92a84e3a0319d.bindPopup(popup_6f2167c11e96202b082aba9a383f2e6a)
+        ;
+
+        
+    
+    
+            var circle_marker_0e83a4678ce2dbbf2edcc16bbf30737e = L.circleMarker(
+                [45.52313, 12.15477],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.160906737311096, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_d8c173b4c5e06ccd31f832d4436b3c6f = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_9e7175fe0c6bce795aa58df4ab4cb6fd = $(`<div id="html_9e7175fe0c6bce795aa58df4ab4cb6fd" style="width: 100.0%; height: 100.0%;">Maerne (IT) — pop 7,168</div>`)[0];
+                popup_d8c173b4c5e06ccd31f832d4436b3c6f.setContent(html_9e7175fe0c6bce795aa58df4ab4cb6fd);
+            
+        
+
+        circle_marker_0e83a4678ce2dbbf2edcc16bbf30737e.bindPopup(popup_d8c173b4c5e06ccd31f832d4436b3c6f)
+        ;
+
+        
+    
+    
+            var circle_marker_03cec23fc0157f4edc638962f110dad2 = L.circleMarker(
+                [45.6628395, 11.8284875],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.159251008489373, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_9eea7da50c8ad6e99599ea8b0f1c464b = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_3dbd84cd1b1584f0319d429381744e1c = $(`<div id="html_3dbd84cd1b1584f0319d429381744e1c" style="width: 100.0%; height: 100.0%;">Galliera Veneta (IT) — pop 7,146</div>`)[0];
+                popup_9eea7da50c8ad6e99599ea8b0f1c464b.setContent(html_3dbd84cd1b1584f0319d429381744e1c);
+            
+        
+
+        circle_marker_03cec23fc0157f4edc638962f110dad2.bindPopup(popup_9eea7da50c8ad6e99599ea8b0f1c464b)
+        ;
+
+        
+    
+    
+            var circle_marker_de9e03916385e7e8ed46af9b3d9e9f64 = L.circleMarker(
+                [47.39173, 11.77245],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.157294238063701, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_6d5ad5beb1bd3a1c6b06947e29e9de9a = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_ed303047e221ea83012b8865161a0a6a = $(`<div id="html_ed303047e221ea83012b8865161a0a6a" style="width: 100.0%; height: 100.0%;">Jenbach (AT) — pop 7,120</div>`)[0];
+                popup_6d5ad5beb1bd3a1c6b06947e29e9de9a.setContent(html_ed303047e221ea83012b8865161a0a6a);
+            
+        
+
+        circle_marker_de9e03916385e7e8ed46af9b3d9e9f64.bindPopup(popup_6d5ad5beb1bd3a1c6b06947e29e9de9a)
+        ;
+
+        
+    
+    
+            var circle_marker_dff9a25709eade24095b17f7251cc780 = L.circleMarker(
+                [47.29572, 11.50593],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.156692154855801, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_f7e4bf9170aaee750eb4f458da1e1f41 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_5fd9b955ce9825d642eb91b1a5251aba = $(`<div id="html_5fd9b955ce9825d642eb91b1a5251aba" style="width: 100.0%; height: 100.0%;">Absam (AT) — pop 7,112</div>`)[0];
+                popup_f7e4bf9170aaee750eb4f458da1e1f41.setContent(html_5fd9b955ce9825d642eb91b1a5251aba);
+            
+        
+
+        circle_marker_dff9a25709eade24095b17f7251cc780.bindPopup(popup_f7e4bf9170aaee750eb4f458da1e1f41)
+        ;
+
+        
+    
+    
+            var circle_marker_faf3e0be15a9de9264e76f96f7ba242f = L.circleMarker(
+                [46.2120936, 11.0935086],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.153305436811367, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_25be9a2d631587528b460fbed447fde2 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_516c799bb1c648d3ceece9fa1b595bf2 = $(`<div id="html_516c799bb1c648d3ceece9fa1b595bf2" style="width: 100.0%; height: 100.0%;">Mezzolombardo (IT) — pop 7,067</div>`)[0];
+                popup_25be9a2d631587528b460fbed447fde2.setContent(html_516c799bb1c648d3ceece9fa1b595bf2);
+            
+        
+
+        circle_marker_faf3e0be15a9de9264e76f96f7ba242f.bindPopup(popup_25be9a2d631587528b460fbed447fde2)
+        ;
+
+        
+    
+    
+            var circle_marker_d60f9e5a4912802efb5d36ceb054506a = L.circleMarker(
+                [45.6287707, 11.6998606],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.15029502077187, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_6e422fa8b6df74d9d0f0bd442ca5f6aa = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_e49dbc556fd8c00996e7537a565a8950 = $(`<div id="html_e49dbc556fd8c00996e7537a565a8950" style="width: 100.0%; height: 100.0%;">Carmignano di Brenta (IT) — pop 7,027</div>`)[0];
+                popup_6e422fa8b6df74d9d0f0bd442ca5f6aa.setContent(html_e49dbc556fd8c00996e7537a565a8950);
+            
+        
+
+        circle_marker_d60f9e5a4912802efb5d36ceb054506a.bindPopup(popup_6e422fa8b6df74d9d0f0bd442ca5f6aa)
+        ;
+
+        
+    
+    
+            var circle_marker_bcc635980ae6cbbdfd746622590cbd6d = L.circleMarker(
+                [47.3915387, 11.7717443],
+                {"bubblingMouseEvents": true, "color": "blue", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "blue", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.149843458365946, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_cd2168326de8de7f59a62aafeddfade1 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_57660f4ee5353f7caffafff47ad0c241 = $(`<div id="html_57660f4ee5353f7caffafff47ad0c241" style="width: 100.0%; height: 100.0%;">Jenbach (DE) — pop 7,021</div>`)[0];
+                popup_cd2168326de8de7f59a62aafeddfade1.setContent(html_57660f4ee5353f7caffafff47ad0c241);
+            
+        
+
+        circle_marker_bcc635980ae6cbbdfd746622590cbd6d.bindPopup(popup_cd2168326de8de7f59a62aafeddfade1)
+        ;
+
+        
+    
+    
+            var circle_marker_bae99783e50aee9b5f41b2f4241ef45f = L.circleMarker(
+                [46.54152, 11.45728],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.147736167138299, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_655c7e6364b1874bc34f31ec0e74a12c = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_73c02caaf3484fa5f820208fc5fc8cac = $(`<div id="html_73c02caaf3484fa5f820208fc5fc8cac" style="width: 100.0%; height: 100.0%;">Renon (IT) — pop 6,993</div>`)[0];
+                popup_655c7e6364b1874bc34f31ec0e74a12c.setContent(html_73c02caaf3484fa5f820208fc5fc8cac);
+            
+        
+
+        circle_marker_bae99783e50aee9b5f41b2f4241ef45f.bindPopup(popup_655c7e6364b1874bc34f31ec0e74a12c)
+        ;
+
+        
+    
+    
+            var circle_marker_ec85be8ad05f1167c7b311bfa369aded = L.circleMarker(
+                [46.3652616, 11.0332447],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.146908302727437, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_f017263c744a3e41b9c3f3ab223844f4 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_db2dd6949e4e17fc5548180f8a9eea7e = $(`<div id="html_db2dd6949e4e17fc5548180f8a9eea7e" style="width: 100.0%; height: 100.0%;">Cles (IT) — pop 6,982</div>`)[0];
+                popup_f017263c744a3e41b9c3f3ab223844f4.setContent(html_db2dd6949e4e17fc5548180f8a9eea7e);
+            
+        
+
+        circle_marker_ec85be8ad05f1167c7b311bfa369aded.bindPopup(popup_f017263c744a3e41b9c3f3ab223844f4)
+        ;
+
+        
+    
+    
+            var circle_marker_b64a923897e19e5aa8bca3e90e1d6fe4 = L.circleMarker(
+                [45.8932811, 12.5960447],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.145553615509663, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_a09f9f6bf0141d14658bd12c6eccb6e5 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_99e569fdbf895c856b110a461f26c0ea = $(`<div id="html_99e569fdbf895c856b110a461f26c0ea" style="width: 100.0%; height: 100.0%;">Prata di Pordenone / Prate (IT) — pop 6,964</div>`)[0];
+                popup_a09f9f6bf0141d14658bd12c6eccb6e5.setContent(html_99e569fdbf895c856b110a461f26c0ea);
+            
+        
+
+        circle_marker_b64a923897e19e5aa8bca3e90e1d6fe4.bindPopup(popup_a09f9f6bf0141d14658bd12c6eccb6e5)
+        ;
+
+        
+    
+    
+            var circle_marker_cc272b06eae30722129d14d103915906 = L.circleMarker(
+                [46.0533463, 11.4566004],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.144123667890902, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_579fc7b1b2bad118e4e520fe314b989c = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_9fb2a85f684cf732e093d148c56fcd42 = $(`<div id="html_9fb2a85f684cf732e093d148c56fcd42" style="width: 100.0%; height: 100.0%;">Borgo Valsugana (IT) — pop 6,945</div>`)[0];
+                popup_579fc7b1b2bad118e4e520fe314b989c.setContent(html_9fb2a85f684cf732e093d148c56fcd42);
+            
+        
+
+        circle_marker_cc272b06eae30722129d14d103915906.bindPopup(popup_579fc7b1b2bad118e4e520fe314b989c)
+        ;
+
+        
+    
+    
+            var circle_marker_d0ce96cc804ed5987e44bc8db21944a0 = L.circleMarker(
+                [45.7540029, 11.9553621],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.1416400746583175, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_6f37ba707d3eba5b775ce0e98dc733b1 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_53623fe6c77584599020d8389f0af981 = $(`<div id="html_53623fe6c77584599020d8389f0af981" style="width: 100.0%; height: 100.0%;">Altivole (IT) — pop 6,912</div>`)[0];
+                popup_6f37ba707d3eba5b775ce0e98dc733b1.setContent(html_53623fe6c77584599020d8389f0af981);
+            
+        
+
+        circle_marker_d0ce96cc804ed5987e44bc8db21944a0.bindPopup(popup_6f37ba707d3eba5b775ce0e98dc733b1)
+        ;
+
+        
+    
+    
+            var circle_marker_30c173d6bf8503783fb14980e3aee9ab = L.circleMarker(
+                [45.690161, 13.1407655],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.140736949846469, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_628b6be938dac6dc0122867f5570aa19 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_9fa7d7f0d415a9fd306013ef61cd9918 = $(`<div id="html_9fa7d7f0d415a9fd306013ef61cd9918" style="width: 100.0%; height: 100.0%;">Lignano Sabbiadoro / Lignan (IT) — pop 6,900</div>`)[0];
+                popup_628b6be938dac6dc0122867f5570aa19.setContent(html_9fa7d7f0d415a9fd306013ef61cd9918);
+            
+        
+
+        circle_marker_30c173d6bf8503783fb14980e3aee9ab.bindPopup(popup_628b6be938dac6dc0122867f5570aa19)
+        ;
+
+        
+    
+    
+            var circle_marker_0f3f33e89bd94960c708dd7a55eff2c8 = L.circleMarker(
+                [45.69001, 11.7718],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.139081221024746, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_9214343bbe946f2e7634c6d655949bab = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_a5f80d3d3806355ba004ab94c4d85156 = $(`<div id="html_a5f80d3d3806355ba004ab94c4d85156" style="width: 100.0%; height: 100.0%;">Belvedere (IT) — pop 6,878</div>`)[0];
+                popup_9214343bbe946f2e7634c6d655949bab.setContent(html_a5f80d3d3806355ba004ab94c4d85156);
+            
+        
+
+        circle_marker_0f3f33e89bd94960c708dd7a55eff2c8.bindPopup(popup_9214343bbe946f2e7634c6d655949bab)
+        ;
+
+        
+    
+    
+            var circle_marker_fa41f4785a0c95406c90b7b090195bbb = L.circleMarker(
+                [46.413467, 11.2469106],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.137124450599073, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_5f80e09bf9b902f71f802cecd9d228cc = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_16bb029b4c73204faeb2230b0627d61b = $(`<div id="html_16bb029b4c73204faeb2230b0627d61b" style="width: 100.0%; height: 100.0%;">Kaltern an der Weinstraße - Caldaro sulla Strada del Vino (IT) — pop 6,852</div>`)[0];
+                popup_5f80e09bf9b902f71f802cecd9d228cc.setContent(html_16bb029b4c73204faeb2230b0627d61b);
+            
+        
+
+        circle_marker_fa41f4785a0c95406c90b7b090195bbb.bindPopup(popup_5f80e09bf9b902f71f802cecd9d228cc)
+        ;
+
+        
+    
+    
+            var circle_marker_5ea941d35ec49079366e6e820b9f0f63 = L.circleMarker(
+                [46.0838843, 12.0432384],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.133737732554639, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_ba78cbcef8b5423fa7e98c89fccb1e13 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_9018315a6139c0434920ee45c4531537 = $(`<div id="html_9018315a6139c0434920ee45c4531537" style="width: 100.0%; height: 100.0%;">Santa Giustina (IT) — pop 6,807</div>`)[0];
+                popup_ba78cbcef8b5423fa7e98c89fccb1e13.setContent(html_9018315a6139c0434920ee45c4531537);
+            
+        
+
+        circle_marker_5ea941d35ec49079366e6e820b9f0f63.bindPopup(popup_ba78cbcef8b5423fa7e98c89fccb1e13)
+        ;
+
+        
+    
+    
+            var circle_marker_036c32abeac4baa98dfaba10841d9ac4 = L.circleMarker(
+                [45.80233, 13.50226],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.133436690950689, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_64d627c67ebabccdc40b949e0310ab62 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_52b86327085a43dacc1dd4809b55a538 = $(`<div id="html_52b86327085a43dacc1dd4809b55a538" style="width: 100.0%; height: 100.0%;">Staranzano (IT) — pop 6,803</div>`)[0];
+                popup_64d627c67ebabccdc40b949e0310ab62.setContent(html_52b86327085a43dacc1dd4809b55a538);
+            
+        
+
+        circle_marker_036c32abeac4baa98dfaba10841d9ac4.bindPopup(popup_64d627c67ebabccdc40b949e0310ab62)
+        ;
+
+        
+    
+    
+            var circle_marker_ad26db05c54084ac8ea9b84264e5d177 = L.circleMarker(
+                [47.2733773, 11.2422348],
+                {"bubblingMouseEvents": true, "color": "blue", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "blue", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.132909868143777, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_fbcec4e1a43fe1ad9dfc2d1630cbb21b = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_e8cf1cf982441dddb8c184e71ec659fa = $(`<div id="html_e8cf1cf982441dddb8c184e71ec659fa" style="width: 100.0%; height: 100.0%;">Zirl (DE) — pop 6,796</div>`)[0];
+                popup_fbcec4e1a43fe1ad9dfc2d1630cbb21b.setContent(html_e8cf1cf982441dddb8c184e71ec659fa);
+            
+        
+
+        circle_marker_ad26db05c54084ac8ea9b84264e5d177.bindPopup(popup_fbcec4e1a43fe1ad9dfc2d1630cbb21b)
+        ;
+
+        
+    
+    
+            var circle_marker_98422253cce1d6a28243480f777ef4c8 = L.circleMarker(
+                [45.67774, 13.40323],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.130727316515142, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_5f3834ac0405c92e10dc5522aaf93e19 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_96f0aa98ca35e46a58b461fe320f7c6a = $(`<div id="html_96f0aa98ca35e46a58b461fe320f7c6a" style="width: 100.0%; height: 100.0%;">Grado (IT) — pop 6,767</div>`)[0];
+                popup_5f3834ac0405c92e10dc5522aaf93e19.setContent(html_96f0aa98ca35e46a58b461fe320f7c6a);
+            
+        
+
+        circle_marker_98422253cce1d6a28243480f777ef4c8.bindPopup(popup_5f3834ac0405c92e10dc5522aaf93e19)
+        ;
+
+        
+    
+    
+            var circle_marker_d0dfcf6402a6caa3e6f1e89bf51a1583 = L.circleMarker(
+                [45.81998, 12.25847],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.1289210668914444, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_62c97043f170e967fc0d8339be526d1e = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_b642fe4967b41d3fcbec4c3d99f34c69 = $(`<div id="html_b642fe4967b41d3fcbec4c3d99f34c69" style="width: 100.0%; height: 100.0%;">Priula-Colfosco (IT) — pop 6,743</div>`)[0];
+                popup_62c97043f170e967fc0d8339be526d1e.setContent(html_b642fe4967b41d3fcbec4c3d99f34c69);
+            
+        
+
+        circle_marker_d0dfcf6402a6caa3e6f1e89bf51a1583.bindPopup(popup_62c97043f170e967fc0d8339be526d1e)
+        ;
+
+        
+    
+    
+            var circle_marker_7d0aee2f5720d8c6ba0c10f3a282b679 = L.circleMarker(
+                [47.25, 11.33333],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.128544764886508, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_bd5136e95e988595624180199c711d46 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_d0f7ffe70270fff760d3531332e22ba9 = $(`<div id="html_d0f7ffe70270fff760d3531332e22ba9" style="width: 100.0%; height: 100.0%;">Völs (AT) — pop 6,738</div>`)[0];
+                popup_bd5136e95e988595624180199c711d46.setContent(html_d0f7ffe70270fff760d3531332e22ba9);
+            
+        
+
+        circle_marker_7d0aee2f5720d8c6ba0c10f3a282b679.bindPopup(popup_bd5136e95e988595624180199c711d46)
+        ;
+
+        
+    
+    
+            var circle_marker_ebaeba66943542c79d9d51593f3b4837 = L.circleMarker(
+                [47.48333, 10.71667],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.125985911252935, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_7c056648e6c1876a307249c2f5ceb4e2 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_52eff7512f209d881dd742eda819fd6d = $(`<div id="html_52eff7512f209d881dd742eda819fd6d" style="width: 100.0%; height: 100.0%;">Reutte (AT) — pop 6,704</div>`)[0];
+                popup_7c056648e6c1876a307249c2f5ceb4e2.setContent(html_52eff7512f209d881dd742eda819fd6d);
+            
+        
+
+        circle_marker_ebaeba66943542c79d9d51593f3b4837.bindPopup(popup_7c056648e6c1876a307249c2f5ceb4e2)
+        ;
+
+        
+    
+    
+            var circle_marker_f4d261a0022c8d144b594238e54412a0 = L.circleMarker(
+                [46.15714, 13.00726],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.125684869648985, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_21e4e2f8237b66323b727813e391ae76 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_9c1645221ababce4490dc538f75363c0 = $(`<div id="html_9c1645221ababce4490dc538f75363c0" style="width: 100.0%; height: 100.0%;">San Daniele del Friuli (IT) — pop 6,700</div>`)[0];
+                popup_21e4e2f8237b66323b727813e391ae76.setContent(html_9c1645221ababce4490dc538f75363c0);
+            
+        
+
+        circle_marker_f4d261a0022c8d144b594238e54412a0.bindPopup(popup_21e4e2f8237b66323b727813e391ae76)
+        ;
+
+        
+    
+    
+            var circle_marker_962f4b83b21d8960ec4148a6715709b0 = L.circleMarker(
+                [45.704123, 12.4925871],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.124781744837136, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_06137be32d8bcf0e7dd1919579e6f747 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_8427577c82325a229f65502bea3a2b14 = $(`<div id="html_8427577c82325a229f65502bea3a2b14" style="width: 100.0%; height: 100.0%;">Salgareda (IT) — pop 6,688</div>`)[0];
+                popup_06137be32d8bcf0e7dd1919579e6f747.setContent(html_8427577c82325a229f65502bea3a2b14);
+            
+        
+
+        circle_marker_962f4b83b21d8960ec4148a6715709b0.bindPopup(popup_06137be32d8bcf0e7dd1919579e6f747)
+        ;
+
+        
+    
+    
+            var circle_marker_4e5fcf86ad279b4a1cfa568b90348a4a = L.circleMarker(
+                [45.4385084, 12.1386165],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.1244054428322, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_7d929ff6a707a43df20949572870b34a = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_ff253112dbdf526f340af85b71c2a9b3 = $(`<div id="html_ff253112dbdf526f340af85b71c2a9b3" style="width: 100.0%; height: 100.0%;">Mira Porte (IT) — pop 6,683</div>`)[0];
+                popup_7d929ff6a707a43df20949572870b34a.setContent(html_ff253112dbdf526f340af85b71c2a9b3);
+            
+        
+
+        circle_marker_4e5fcf86ad279b4a1cfa568b90348a4a.bindPopup(popup_7d929ff6a707a43df20949572870b34a)
+        ;
+
+        
+    
+    
+            var circle_marker_f6ed185ed35e5d4f2f91862c2287e292 = L.circleMarker(
+                [46.2066766, 13.118557],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.123728099223313, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_c2f743c3787873a8a3e4c5c8a2292c2c = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_9368956416f5191c8f7f92b56e9415ff = $(`<div id="html_9368956416f5191c8f7f92b56e9415ff" style="width: 100.0%; height: 100.0%;">Buja / Buie (IT) — pop 6,674</div>`)[0];
+                popup_c2f743c3787873a8a3e4c5c8a2292c2c.setContent(html_9368956416f5191c8f7f92b56e9415ff);
+            
+        
+
+        circle_marker_f6ed185ed35e5d4f2f91862c2287e292.bindPopup(popup_c2f743c3787873a8a3e4c5c8a2292c2c)
+        ;
+
+        
+    
+    
+            var circle_marker_8f4f17b28ec39967e6ebd760dcd4419e = L.circleMarker(
+                [45.8253685, 12.2092015],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.122147630802577, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_06ca161d7618e6adf26a5ca262ceaf1b = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_8dd65207ab599083910b5904fa6d7f7a = $(`<div id="html_8dd65207ab599083910b5904fa6d7f7a" style="width: 100.0%; height: 100.0%;">Nervesa della Battaglia (IT) — pop 6,653</div>`)[0];
+                popup_06ca161d7618e6adf26a5ca262ceaf1b.setContent(html_8dd65207ab599083910b5904fa6d7f7a);
+            
+        
+
+        circle_marker_8f4f17b28ec39967e6ebd760dcd4419e.bindPopup(popup_06ca161d7618e6adf26a5ca262ceaf1b)
+        ;
+
+        
+    
+    
+            var circle_marker_609252b95a1e2048f0db96699d2b8b00 = L.circleMarker(
+                [47.35438, 9.65207],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.119965079173942, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_e8ab16e4853f4abea69bf93e595ca9c5 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_5b9938245909d69620c620893716b305 = $(`<div id="html_5b9938245909d69620c620893716b305" style="width: 100.0%; height: 100.0%;">Altach (AT) — pop 6,624</div>`)[0];
+                popup_e8ab16e4853f4abea69bf93e595ca9c5.setContent(html_5b9938245909d69620c620893716b305);
+            
+        
+
+        circle_marker_609252b95a1e2048f0db96699d2b8b00.bindPopup(popup_e8ab16e4853f4abea69bf93e595ca9c5)
+        ;
+
+        
+    
+    
+            var circle_marker_632d452b5eb58f9251e8dc7631c97430 = L.circleMarker(
+                [45.722, 11.44932],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.118158829550244, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_16e759bd5d2157dfeeef783f2a7d7cfb = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_760569c1bb16c7cb1dd80bd8bcb84139 = $(`<div id="html_760569c1bb16c7cb1dd80bd8bcb84139" style="width: 100.0%; height: 100.0%;">Zanè (IT) — pop 6,600</div>`)[0];
+                popup_16e759bd5d2157dfeeef783f2a7d7cfb.setContent(html_760569c1bb16c7cb1dd80bd8bcb84139);
+            
+        
+
+        circle_marker_632d452b5eb58f9251e8dc7631c97430.bindPopup(popup_16e759bd5d2157dfeeef783f2a7d7cfb)
+        ;
+
+        
+    
+    
+            var circle_marker_20a3bbba974d53e58a59aea9b1cf2583 = L.circleMarker(
+                [46.59963, 13.84389],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.115374194713709, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_4434aa01f4de34d13ee043c9a25988eb = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_35db867422c326814e359028452e5915 = $(`<div id="html_35db867422c326814e359028452e5915" style="width: 100.0%; height: 100.0%;">Auen (AT) — pop 6,563</div>`)[0];
+                popup_4434aa01f4de34d13ee043c9a25988eb.setContent(html_35db867422c326814e359028452e5915);
+            
+        
+
+        circle_marker_20a3bbba974d53e58a59aea9b1cf2583.bindPopup(popup_4434aa01f4de34d13ee043c9a25988eb)
+        ;
+
+        
+    
+    
+            var circle_marker_21f214f999d7dbf5c0a55bd8d063de22 = L.circleMarker(
+                [47.2965003, 11.5051409],
+                {"bubblingMouseEvents": true, "color": "blue", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "blue", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.113868986693961, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_c3d21280ffc86398ef87fc982221d15e = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_cdd7c761e6a3c0d4112fa09e746aee79 = $(`<div id="html_cdd7c761e6a3c0d4112fa09e746aee79" style="width: 100.0%; height: 100.0%;">Absam (DE) — pop 6,543</div>`)[0];
+                popup_c3d21280ffc86398ef87fc982221d15e.setContent(html_cdd7c761e6a3c0d4112fa09e746aee79);
+            
+        
+
+        circle_marker_21f214f999d7dbf5c0a55bd8d063de22.bindPopup(popup_c3d21280ffc86398ef87fc982221d15e)
+        ;
+
+        
+    
+    
+            var circle_marker_5db33c26ca041b622b27163d779cfc18 = L.circleMarker(
+                [47.58261, 9.91352],
+                {"bubblingMouseEvents": true, "color": "blue", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "blue", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.111385393461377, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_f33ea2a2d2c71717ae8ef6ecda05c58b = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_90637f648fb05d32b2646ffa115b0601 = $(`<div id="html_90637f648fb05d32b2646ffa115b0601" style="width: 100.0%; height: 100.0%;">Weiler-Simmerberg (DE) — pop 6,510</div>`)[0];
+                popup_f33ea2a2d2c71717ae8ef6ecda05c58b.setContent(html_90637f648fb05d32b2646ffa115b0601);
+            
+        
+
+        circle_marker_5db33c26ca041b622b27163d779cfc18.bindPopup(popup_f33ea2a2d2c71717ae8ef6ecda05c58b)
+        ;
+
+        
+    
+    
+            var circle_marker_5ee847ea7aab356077d2f1d646539c76 = L.circleMarker(
+                [46.21251, 13.21514],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.109503883436691, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_2c4385d85555d98e17508e24c7bb2326 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_e18357e972554630e33c2e9389b73dfc = $(`<div id="html_e18357e972554630e33c2e9389b73dfc" style="width: 100.0%; height: 100.0%;">Tarcento (IT) — pop 6,485</div>`)[0];
+                popup_2c4385d85555d98e17508e24c7bb2326.setContent(html_e18357e972554630e33c2e9389b73dfc);
+            
+        
+
+        circle_marker_5ee847ea7aab356077d2f1d646539c76.bindPopup(popup_2c4385d85555d98e17508e24c7bb2326)
+        ;
+
+        
+    
+    
+            var circle_marker_77012466ad1ba221c403725b961e4c32 = L.circleMarker(
+                [45.7051709, 11.2249347],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.107095550605093, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_7b7f4b8c899acae2621cb5f1dc33ac62 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_dab3249f40bfc1c2ace83bab886da803 = $(`<div id="html_dab3249f40bfc1c2ace83bab886da803" style="width: 100.0%; height: 100.0%;">Recoaro Terme (IT) — pop 6,453</div>`)[0];
+                popup_7b7f4b8c899acae2621cb5f1dc33ac62.setContent(html_dab3249f40bfc1c2ace83bab886da803);
+            
+        
+
+        circle_marker_77012466ad1ba221c403725b961e4c32.bindPopup(popup_7b7f4b8c899acae2621cb5f1dc33ac62)
+        ;
+
+        
+    
+    
+            var circle_marker_0b823ba8552237c8fc33783ea92a1658 = L.circleMarker(
+                [47.21735, 9.62995],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.105665602986333, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_2ba54d7fe20951c8079a690e182675b2 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_3bec4dacaa3934b8fd3ac6293eafbd6d = $(`<div id="html_3bec4dacaa3934b8fd3ac6293eafbd6d" style="width: 100.0%; height: 100.0%;">Frastanz (AT) — pop 6,434</div>`)[0];
+                popup_2ba54d7fe20951c8079a690e182675b2.setContent(html_3bec4dacaa3934b8fd3ac6293eafbd6d);
+            
+        
+
+        circle_marker_0b823ba8552237c8fc33783ea92a1658.bindPopup(popup_2ba54d7fe20951c8079a690e182675b2)
+        ;
+
+        
+    
+    
+            var circle_marker_635dfc5f460ffd222f6e5168395bc96a = L.circleMarker(
+                [45.8925, 13.50167],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.105439821783371, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_b1e186632d0fc3df9d1a07aedf985c21 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_ccf6d0bb59159bd2605c35572afb7588 = $(`<div id="html_ccf6d0bb59159bd2605c35572afb7588" style="width: 100.0%; height: 100.0%;">Gradisca d'Isonzo (IT) — pop 6,431</div>`)[0];
+                popup_b1e186632d0fc3df9d1a07aedf985c21.setContent(html_ccf6d0bb59159bd2605c35572afb7588);
+            
+        
+
+        circle_marker_635dfc5f460ffd222f6e5168395bc96a.bindPopup(popup_b1e186632d0fc3df9d1a07aedf985c21)
+        ;
+
+        
+    
+    
+            var circle_marker_8f49a94bdd2445319e2d761133760145 = L.circleMarker(
+                [45.8753771, 11.5106998],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.105138780179421, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_2c80031b85a4fc996e157de45db3b996 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_e4a6c24d70c9622c8ce16f9cfa30d23e = $(`<div id="html_e4a6c24d70c9622c8ce16f9cfa30d23e" style="width: 100.0%; height: 100.0%;">Asiago (IT) — pop 6,427</div>`)[0];
+                popup_2c80031b85a4fc996e157de45db3b996.setContent(html_e4a6c24d70c9622c8ce16f9cfa30d23e);
+            
+        
+
+        circle_marker_8f49a94bdd2445319e2d761133760145.bindPopup(popup_2c80031b85a4fc996e157de45db3b996)
+        ;
+
+        
+    
+    
+            var circle_marker_a2f6fe948d79096f62bb7b6866038fee = L.circleMarker(
+                [45.8376705, 12.3795417],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.103483051357697, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_d6d71141edd1404b2f2b6815f18ef036 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_1e3f490316e2f2360af224bda6c85c9d = $(`<div id="html_1e3f490316e2f2360af224bda6c85c9d" style="width: 100.0%; height: 100.0%;">Vazzola (IT) — pop 6,405</div>`)[0];
+                popup_d6d71141edd1404b2f2b6815f18ef036.setContent(html_1e3f490316e2f2360af224bda6c85c9d);
+            
+        
+
+        circle_marker_a2f6fe948d79096f62bb7b6866038fee.bindPopup(popup_d6d71141edd1404b2f2b6815f18ef036)
+        ;
+
+        
+    
+    
+            var circle_marker_96fd089801bb680c8c7a28aefd679f11 = L.circleMarker(
+                [45.9489699, 12.4160204],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.101149978927087, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_778159b7c089b62755643c7088dcf087 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_90481e8e1bff3aa2fe4f1ec518c1235e = $(`<div id="html_90481e8e1bff3aa2fe4f1ec518c1235e" style="width: 100.0%; height: 100.0%;">Cordignano (IT) — pop 6,374</div>`)[0];
+                popup_778159b7c089b62755643c7088dcf087.setContent(html_90481e8e1bff3aa2fe4f1ec518c1235e);
+            
+        
+
+        circle_marker_96fd089801bb680c8c7a28aefd679f11.bindPopup(popup_778159b7c089b62755643c7088dcf087)
+        ;
+
+        
+    
+    
+            var circle_marker_c317c63ad28061b5f72a134d992bed98 = L.circleMarker(
+                [45.7237273, 12.3312346],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.099193208501415, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_b1f44cff3664e7563c986ccfebcc2722 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_b709479f95063b87ab7144f4370b7688 = $(`<div id="html_b709479f95063b87ab7144f4370b7688" style="width: 100.0%; height: 100.0%;">Breda di Piave (IT) — pop 6,348</div>`)[0];
+                popup_b1f44cff3664e7563c986ccfebcc2722.setContent(html_b709479f95063b87ab7144f4370b7688);
+            
+        
+
+        circle_marker_c317c63ad28061b5f72a134d992bed98.bindPopup(popup_b1f44cff3664e7563c986ccfebcc2722)
+        ;
+
+        
+    
+    
+            var circle_marker_a5008bcdf0bedd227dcbdf30251507cb = L.circleMarker(
+                [45.6923801, 11.8810438],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.099117948100427, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_aa62ac5ba1801a7fcf529902c1adc061 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_d1f8a3115bcf5303ed0aab552411b544 = $(`<div id="html_d1f8a3115bcf5303ed0aab552411b544" style="width: 100.0%; height: 100.0%;">Castello di Godego (IT) — pop 6,347</div>`)[0];
+                popup_aa62ac5ba1801a7fcf529902c1adc061.setContent(html_d1f8a3115bcf5303ed0aab552411b544);
+            
+        
+
+        circle_marker_a5008bcdf0bedd227dcbdf30251507cb.bindPopup(popup_aa62ac5ba1801a7fcf529902c1adc061)
+        ;
+
+        
+    
+    
+            var circle_marker_162a25d98258fb851185e301715c4477 = L.circleMarker(
+                [47.55, 9.75],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.09904268769944, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_59fee9bffa5000cf6663785a9aed51b8 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_ab5a1d8117b1c19a876880d945466574 = $(`<div id="html_ab5a1d8117b1c19a876880d945466574" style="width: 100.0%; height: 100.0%;">Hörbranz (AT) — pop 6,346</div>`)[0];
+                popup_59fee9bffa5000cf6663785a9aed51b8.setContent(html_ab5a1d8117b1c19a876880d945466574);
+            
+        
+
+        circle_marker_162a25d98258fb851185e301715c4477.bindPopup(popup_59fee9bffa5000cf6663785a9aed51b8)
+        ;
+
+        
+    
+    
+            var circle_marker_aff5498581d232505107ca21c1cfebfd = L.circleMarker(
+                [46.21222, 13.11691],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.097612740080679, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_2a6edcc28b67ff668041fe0b3da5f8a4 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_6dd1811bcfb4e7ca8252db07cda722c6 = $(`<div id="html_6dd1811bcfb4e7ca8252db07cda722c6" style="width: 100.0%; height: 100.0%;">Buia (IT) — pop 6,327</div>`)[0];
+                popup_2a6edcc28b67ff668041fe0b3da5f8a4.setContent(html_6dd1811bcfb4e7ca8252db07cda722c6);
+            
+        
+
+        circle_marker_aff5498581d232505107ca21c1cfebfd.bindPopup(popup_2a6edcc28b67ff668041fe0b3da5f8a4)
+        ;
+
+        
+    
+    
+            var circle_marker_1a60b3c4eab6e069fbfe74052ea650ef = L.circleMarker(
+                [45.9686618, 12.448097],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.097311698476729, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_b3176fcaf525f8a1a3848dafd37ea029 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_1015201ed0d083767f9267d16b39bc06 = $(`<div id="html_1015201ed0d083767f9267d16b39bc06" style="width: 100.0%; height: 100.0%;">Caneva (IT) — pop 6,323</div>`)[0];
+                popup_b3176fcaf525f8a1a3848dafd37ea029.setContent(html_1015201ed0d083767f9267d16b39bc06);
+            
+        
+
+        circle_marker_1a60b3c4eab6e069fbfe74052ea650ef.bindPopup(popup_b3176fcaf525f8a1a3848dafd37ea029)
+        ;
+
+        
+    
+    
+            var circle_marker_3554c1c59416abc529fea55d8e9fc1d0 = L.circleMarker(
+                [45.8476416, 12.8155309],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.096784875669818, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_58a62a18f16a769d8250ec94df007fe3 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_a57f718d517f49aae0b0065f71be6b0c = $(`<div id="html_a57f718d517f49aae0b0065f71be6b0c" style="width: 100.0%; height: 100.0%;">Sesto al Reghena / Siest (IT) — pop 6,316</div>`)[0];
+                popup_58a62a18f16a769d8250ec94df007fe3.setContent(html_a57f718d517f49aae0b0065f71be6b0c);
+            
+        
+
+        circle_marker_3554c1c59416abc529fea55d8e9fc1d0.bindPopup(popup_58a62a18f16a769d8250ec94df007fe3)
+        ;
+
+        
+    
+    
+            var circle_marker_f9a36efe8d0315d52c1f4620d3fcd883 = L.circleMarker(
+                [45.986019, 13.195029],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.09640857366488, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_d5cc74d6eca89cf9cbcf3cae84df65ff = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_f45c5ffd170040235c265120053dfecc = $(`<div id="html_f45c5ffd170040235c265120053dfecc" style="width: 100.0%; height: 100.0%;">Pozzuolo del Friuli / Puçui (IT) — pop 6,311</div>`)[0];
+                popup_d5cc74d6eca89cf9cbcf3cae84df65ff.setContent(html_f45c5ffd170040235c265120053dfecc);
+            
+        
+
+        circle_marker_f9a36efe8d0315d52c1f4620d3fcd883.bindPopup(popup_d5cc74d6eca89cf9cbcf3cae84df65ff)
+        ;
+
+        
+    
+    
+            var circle_marker_0fc803d8483ff6af15aef5413cc7a501 = L.circleMarker(
+                [45.45751, 11.88555],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.093924980432296, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_f18b4e1c71081764f8b98671890d7819 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_d8a7665993ae90ed176672ad7a87eb2e = $(`<div id="html_d8a7665993ae90ed176672ad7a87eb2e" style="width: 100.0%; height: 100.0%;">Vigodarzere (IT) — pop 6,278</div>`)[0];
+                popup_f18b4e1c71081764f8b98671890d7819.setContent(html_d8a7665993ae90ed176672ad7a87eb2e);
+            
+        
+
+        circle_marker_0fc803d8483ff6af15aef5413cc7a501.bindPopup(popup_f18b4e1c71081764f8b98671890d7819)
+        ;
+
+        
+    
+    
+            var circle_marker_274ba65ae8bb3ffb1280f24c9ba10c98 = L.circleMarker(
+                [45.82745, 13.21088],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.089484616774038, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_cd6b2b19cac69ff0ecb9451e6333b4ad = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_1fadc485af122517239daf38cd3a535d = $(`<div id="html_1fadc485af122517239daf38cd3a535d" style="width: 100.0%; height: 100.0%;">San Giorgio di Nogaro (IT) — pop 6,219</div>`)[0];
+                popup_cd6b2b19cac69ff0ecb9451e6333b4ad.setContent(html_1fadc485af122517239daf38cd3a535d);
+            
+        
+
+        circle_marker_274ba65ae8bb3ffb1280f24c9ba10c98.bindPopup(popup_cd6b2b19cac69ff0ecb9451e6333b4ad)
+        ;
+
+        
+    
+    
+            var circle_marker_59bb4a46ef71f7f064f651da5e9a3c1d = L.circleMarker(
+                [46.41326, 11.24616],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.086775242338491, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_04ebe6221b67989f636e2d231d44018c = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_4b36e852bb056f989997038456e6b1fd = $(`<div id="html_4b36e852bb056f989997038456e6b1fd" style="width: 100.0%; height: 100.0%;">Caldaro sulla Strada del Vino (IT) — pop 6,183</div>`)[0];
+                popup_04ebe6221b67989f636e2d231d44018c.setContent(html_4b36e852bb056f989997038456e6b1fd);
+            
+        
+
+        circle_marker_59bb4a46ef71f7f064f651da5e9a3c1d.bindPopup(popup_04ebe6221b67989f636e2d231d44018c)
+        ;
+
+        
+    
+    
+            var circle_marker_3760d3ffd5a71b4cbce0398a3d3e7410 = L.circleMarker(
+                [45.7336727, 11.5214968],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.085495815521705, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_5d2b82ea00ecd8eff0b93a16bb5b3e2f = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_811192b05f1e1880cf4fa979f5087680 = $(`<div id="html_811192b05f1e1880cf4fa979f5087680" style="width: 100.0%; height: 100.0%;">Zugliano (IT) — pop 6,166</div>`)[0];
+                popup_5d2b82ea00ecd8eff0b93a16bb5b3e2f.setContent(html_811192b05f1e1880cf4fa979f5087680);
+            
+        
+
+        circle_marker_3760d3ffd5a71b4cbce0398a3d3e7410.bindPopup(popup_5d2b82ea00ecd8eff0b93a16bb5b3e2f)
+        ;
+
+        
+    
+    
+            var circle_marker_6b1e5af7e7ff917254820c495766618c = L.circleMarker(
+                [45.8805037, 12.4815909],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.085119513516768, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_00ac773aab5eddc4e8b401c3e70c8650 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_9d140d639d70666f37d337c311c8bc0e = $(`<div id="html_9d140d639d70666f37d337c311c8bc0e" style="width: 100.0%; height: 100.0%;">Gaiarine (IT) — pop 6,161</div>`)[0];
+                popup_00ac773aab5eddc4e8b401c3e70c8650.setContent(html_9d140d639d70666f37d337c311c8bc0e);
+            
+        
+
+        circle_marker_6b1e5af7e7ff917254820c495766618c.bindPopup(popup_00ac773aab5eddc4e8b401c3e70c8650)
+        ;
+
+        
+    
+    
+            var circle_marker_b87dada1249c8588e229001491b43f87 = L.circleMarker(
+                [45.920753, 12.3581506],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.0845174303088685, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_9e8307ac2997d0c2c19315049565ba07 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_46cae443ebd5fae14ecd48224e535f41 = $(`<div id="html_46cae443ebd5fae14ecd48224e535f41" style="width: 100.0%; height: 100.0%;">San Fior (IT) — pop 6,153</div>`)[0];
+                popup_9e8307ac2997d0c2c19315049565ba07.setContent(html_46cae443ebd5fae14ecd48224e535f41);
+            
+        
+
+        circle_marker_b87dada1249c8588e229001491b43f87.bindPopup(popup_9e8307ac2997d0c2c19315049565ba07)
+        ;
+
+        
+    
+    
+            var circle_marker_d9d0abdf699d59fb0f15836a89689fe2 = L.circleMarker(
+                [45.42477, 12.32906],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.084065867902944, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_a79b1d691b6df2f9d8b1180bdfe8c40c = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_fe8cd6e546e09c5be11f9420005c13a2 = $(`<div id="html_fe8cd6e546e09c5be11f9420005c13a2" style="width: 100.0%; height: 100.0%;">Giudecca (IT) — pop 6,147</div>`)[0];
+                popup_a79b1d691b6df2f9d8b1180bdfe8c40c.setContent(html_fe8cd6e546e09c5be11f9420005c13a2);
+            
+        
+
+        circle_marker_d9d0abdf699d59fb0f15836a89689fe2.bindPopup(popup_a79b1d691b6df2f9d8b1180bdfe8c40c)
+        ;
+
+        
+    
+    
+            var circle_marker_90b02654bb5e4a42f852432f7f5fa180 = L.circleMarker(
+                [45.6864366, 12.6375286],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.0839153471009695, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_3aa1054f5005a3c7b8ffde7a0e0f5131 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_47e399fd8bf2eaf6977cb764a05352fb = $(`<div id="html_47e399fd8bf2eaf6977cb764a05352fb" style="width: 100.0%; height: 100.0%;">Ceggia (IT) — pop 6,145</div>`)[0];
+                popup_3aa1054f5005a3c7b8ffde7a0e0f5131.setContent(html_47e399fd8bf2eaf6977cb764a05352fb);
+            
+        
+
+        circle_marker_90b02654bb5e4a42f852432f7f5fa180.bindPopup(popup_3aa1054f5005a3c7b8ffde7a0e0f5131)
+        ;
+
+        
+    
+    
+            var circle_marker_ed08e1a0d0e777777ea8d8cfe7dfe6e9 = L.circleMarker(
+                [45.4904556, 11.9730203],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.083463784695045, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_caffeda3dfbcb9ccced5cbcb498eb2b0 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_ce50d611695ef4fc59d656daa6ad0caf = $(`<div id="html_ce50d611695ef4fc59d656daa6ad0caf" style="width: 100.0%; height: 100.0%;">Villanova di Camposampiero (IT) — pop 6,139</div>`)[0];
+                popup_caffeda3dfbcb9ccced5cbcb498eb2b0.setContent(html_ce50d611695ef4fc59d656daa6ad0caf);
+            
+        
+
+        circle_marker_ed08e1a0d0e777777ea8d8cfe7dfe6e9.bindPopup(popup_caffeda3dfbcb9ccced5cbcb498eb2b0)
+        ;
+
+        
+    
+    
+            var circle_marker_4e716a388668d534a0c7d8a47f673dd3 = L.circleMarker(
+                [45.6194293, 12.4530566],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.077066650611115, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_b31ff4122a10e86e0356bea5613fb8fe = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_17a251b702c116d3807e0f68e8856a57 = $(`<div id="html_17a251b702c116d3807e0f68e8856a57" style="width: 100.0%; height: 100.0%;">Meolo (IT) — pop 6,054</div>`)[0];
+                popup_b31ff4122a10e86e0356bea5613fb8fe.setContent(html_17a251b702c116d3807e0f68e8856a57);
+            
+        
+
+        circle_marker_4e716a388668d534a0c7d8a47f673dd3.bindPopup(popup_b31ff4122a10e86e0356bea5613fb8fe)
+        ;
+
+        
+    
+    
+            var circle_marker_649ae9be869b2af91c5acc41f19937c6 = L.circleMarker(
+                [45.5555115, 12.0074344],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.076389307002228, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_2bc0fcc6211647a9f978a695ffbfec5f = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_de112c819ecffc8ad68e70812abdb801 = $(`<div id="html_de112c819ecffc8ad68e70812abdb801" style="width: 100.0%; height: 100.0%;">Massanzago (IT) — pop 6,045</div>`)[0];
+                popup_2bc0fcc6211647a9f978a695ffbfec5f.setContent(html_de112c819ecffc8ad68e70812abdb801);
+            
+        
+
+        circle_marker_649ae9be869b2af91c5acc41f19937c6.bindPopup(popup_2bc0fcc6211647a9f978a695ffbfec5f)
+        ;
+
+        
+    
+    
+            var circle_marker_d02ca01cb338dd2bc30c6d106c09eb6f = L.circleMarker(
+                [46.1134401, 13.0845716],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.0756367029923535, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_c6114597b7abb2ecd91e720e14079a4f = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_19eeaa69325281ee03b192c62c2da0d8 = $(`<div id="html_19eeaa69325281ee03b192c62c2da0d8" style="width: 100.0%; height: 100.0%;">Fagagna / Feagne (IT) — pop 6,035</div>`)[0];
+                popup_c6114597b7abb2ecd91e720e14079a4f.setContent(html_19eeaa69325281ee03b192c62c2da0d8);
+            
+        
+
+        circle_marker_d02ca01cb338dd2bc30c6d106c09eb6f.bindPopup(popup_c6114597b7abb2ecd91e720e14079a4f)
+        ;
+
+        
+    
+    
+            var circle_marker_e455a3c0822bed4b7ec07d18229534fa = L.circleMarker(
+                [45.8918, 12.32992],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.075561442591366, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_1a289af5211a5655d32ec6a2ac89c132 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_0f2054bc83c48ed87e6b7e933938667e = $(`<div id="html_0f2054bc83c48ed87e6b7e933938667e" style="width: 100.0%; height: 100.0%;">San Vendemiano-Fossamerlo (IT) — pop 6,034</div>`)[0];
+                popup_1a289af5211a5655d32ec6a2ac89c132.setContent(html_0f2054bc83c48ed87e6b7e933938667e);
+            
+        
+
+        circle_marker_e455a3c0822bed4b7ec07d18229534fa.bindPopup(popup_1a289af5211a5655d32ec6a2ac89c132)
+        ;
+
+        
+    
+    
+            var circle_marker_a21bb00676e38205a4a30363f057fc92 = L.circleMarker(
+                [46.5678425, 11.5596852],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.07255102655187, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_043fd51ba13396ef2d90913c1ca4b8c8 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_5e165b487ad02c07ffc5e093b853bf21 = $(`<div id="html_5e165b487ad02c07ffc5e093b853bf21" style="width: 100.0%; height: 100.0%;">Kastelruth - Ciastel - Castelrotto (IT) — pop 5,994</div>`)[0];
+                popup_043fd51ba13396ef2d90913c1ca4b8c8.setContent(html_5e165b487ad02c07ffc5e093b853bf21);
+            
+        
+
+        circle_marker_a21bb00676e38205a4a30363f057fc92.bindPopup(popup_043fd51ba13396ef2d90913c1ca4b8c8)
+        ;
+
+        
+    
+    
+            var circle_marker_4f042330ece24067bc0d1e29dd6650ba = L.circleMarker(
+                [46.45472, 11.26178],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.070518995725209, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_3d96d112e5b482a862c9aae3f81f78cc = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_4ca069a0cf1d60e93b727c52af23d6ed = $(`<div id="html_4ca069a0cf1d60e93b727c52af23d6ed" style="width: 100.0%; height: 100.0%;">San Michele (IT) — pop 5,967</div>`)[0];
+                popup_3d96d112e5b482a862c9aae3f81f78cc.setContent(html_4ca069a0cf1d60e93b727c52af23d6ed);
+            
+        
+
+        circle_marker_4f042330ece24067bc0d1e29dd6650ba.bindPopup(popup_3d96d112e5b482a862c9aae3f81f78cc)
+        ;
+
+        
+    
+    
+            var circle_marker_e56fc80c66a55cc289551b4203987124 = L.circleMarker(
+                [45.9298483, 12.3981101],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.069540610512373, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_9ea7d130aa3ffd19e82c0c484317905a = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_38684301710d2e1c95d9b91670a38d0a = $(`<div id="html_38684301710d2e1c95d9b91670a38d0a" style="width: 100.0%; height: 100.0%;">Godega di Sant'Urbano (IT) — pop 5,954</div>`)[0];
+                popup_9ea7d130aa3ffd19e82c0c484317905a.setContent(html_38684301710d2e1c95d9b91670a38d0a);
+            
+        
+
+        circle_marker_e56fc80c66a55cc289551b4203987124.bindPopup(popup_9ea7d130aa3ffd19e82c0c484317905a)
+        ;
+
+        
+    
+    
+            var circle_marker_acbbe30aad68fc1613f5186fdeaff597 = L.circleMarker(
+                [45.6618875, 12.5299422],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.069390089710398, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_101ad615e09c7afdb364406684ee1d41 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_addf98154c97dc35b82859a05f9ace7b = $(`<div id="html_addf98154c97dc35b82859a05f9ace7b" style="width: 100.0%; height: 100.0%;">Noventa di Piave (IT) — pop 5,952</div>`)[0];
+                popup_101ad615e09c7afdb364406684ee1d41.setContent(html_addf98154c97dc35b82859a05f9ace7b);
+            
+        
+
+        circle_marker_acbbe30aad68fc1613f5186fdeaff597.bindPopup(popup_101ad615e09c7afdb364406684ee1d41)
+        ;
+
+        
+    
+    
+            var circle_marker_978a45739a6c665c5c95226943888d57 = L.circleMarker(
+                [45.7181164, 11.6070356],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.066078632066952, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_d272fe11dcc2d5294056f3de57b706c1 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_ea5d54f897a70efcb6c19f0b3e3e6903 = $(`<div id="html_ea5d54f897a70efcb6c19f0b3e3e6903" style="width: 100.0%; height: 100.0%;">Colceresa (IT) — pop 5,908</div>`)[0];
+                popup_d272fe11dcc2d5294056f3de57b706c1.setContent(html_ea5d54f897a70efcb6c19f0b3e3e6903);
+            
+        
+
+        circle_marker_978a45739a6c665c5c95226943888d57.bindPopup(popup_d272fe11dcc2d5294056f3de57b706c1)
+        ;
+
+        
+    
+    
+            var circle_marker_07517ee46a1c5f3b6b267bf052d27cac = L.circleMarker(
+                [46.5383332, 12.1373506],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.066003371665964, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_00e80ac770cef67e3eabceca9243e2b4 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_9fd415e0391c43303a7feed8c03488b1 = $(`<div id="html_9fd415e0391c43303a7feed8c03488b1" style="width: 100.0%; height: 100.0%;">Cortina d'Ampezzo (IT) — pop 5,907</div>`)[0];
+                popup_00e80ac770cef67e3eabceca9243e2b4.setContent(html_9fd415e0391c43303a7feed8c03488b1);
+            
+        
+
+        circle_marker_07517ee46a1c5f3b6b267bf052d27cac.bindPopup(popup_00e80ac770cef67e3eabceca9243e2b4)
+        ;
+
+        
+    
+    
+            var circle_marker_0880d80e11ba34a230e13114c05634f1 = L.circleMarker(
+                [45.89126, 6.71678],
+                {"bubblingMouseEvents": true, "color": "green", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "green", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.064121861641278, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_a4e59f276646836a0c9eff186b026170 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_16383816a505606d2321250e2fca486c = $(`<div id="html_16383816a505606d2321250e2fca486c" style="width: 100.0%; height: 100.0%;">Saint-Gervais-les-Bains (FR) — pop 5,882</div>`)[0];
+                popup_a4e59f276646836a0c9eff186b026170.setContent(html_16383816a505606d2321250e2fca486c);
+            
+        
+
+        circle_marker_0880d80e11ba34a230e13114c05634f1.bindPopup(popup_a4e59f276646836a0c9eff186b026170)
+        ;
+
+        
+    
+    
+            var circle_marker_54682add11411eba50669772a1614470 = L.circleMarker(
+                [46.185205, 13.0682141],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.063745559636342, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_f0ad22e43c9f6e63dc38259399a24f9d = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_af7d018d4ce9e1f3ee1e9b32e5679123 = $(`<div id="html_af7d018d4ce9e1f3ee1e9b32e5679123" style="width: 100.0%; height: 100.0%;">Majano / Maian (IT) — pop 5,877</div>`)[0];
+                popup_f0ad22e43c9f6e63dc38259399a24f9d.setContent(html_af7d018d4ce9e1f3ee1e9b32e5679123);
+            
+        
+
+        circle_marker_54682add11411eba50669772a1614470.bindPopup(popup_f0ad22e43c9f6e63dc38259399a24f9d)
+        ;
+
+        
+    
+    
+            var circle_marker_44effd3f0e9b11a58b2c4d9f258801c4 = L.circleMarker(
+                [47.51743, 12.09629],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.062089830814618, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_e19843cd500b51602d49fee0b60624db = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_7526d61b41036bdb86a54bb6e1f48264 = $(`<div id="html_7526d61b41036bdb86a54bb6e1f48264" style="width: 100.0%; height: 100.0%;">Kirchbichl (AT) — pop 5,855</div>`)[0];
+                popup_e19843cd500b51602d49fee0b60624db.setContent(html_7526d61b41036bdb86a54bb6e1f48264);
+            
+        
+
+        circle_marker_44effd3f0e9b11a58b2c4d9f258801c4.bindPopup(popup_e19843cd500b51602d49fee0b60624db)
+        ;
+
+        
+    
+    
+            var circle_marker_c26e72ad6b688cb294f1f9ab44698566 = L.circleMarker(
+                [45.7917474, 12.9090234],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.061186706002769, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_ffc0db8787348c46cdb759989ea499d1 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_6fdb0ea4df20cdcd4039dc804dabeeb0 = $(`<div id="html_6fdb0ea4df20cdcd4039dc804dabeeb0" style="width: 100.0%; height: 100.0%;">Fossalta di Portogruaro (IT) — pop 5,843</div>`)[0];
+                popup_ffc0db8787348c46cdb759989ea499d1.setContent(html_6fdb0ea4df20cdcd4039dc804dabeeb0);
+            
+        
+
+        circle_marker_c26e72ad6b688cb294f1f9ab44698566.bindPopup(popup_ffc0db8787348c46cdb759989ea499d1)
+        ;
+
+        
+    
+    
+            var circle_marker_aeca0a6987e5d190318b4aa0e819c282 = L.circleMarker(
+                [45.6759, 13.11727],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.060735143596845, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_aa1138b3f92069e8cd5ae32530e71da2 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_498d1ca3e88a5c5c5ca8be6a519a35d8 = $(`<div id="html_498d1ca3e88a5c5c5ca8be6a519a35d8" style="width: 100.0%; height: 100.0%;">Lignano Sabbiadoro (IT) — pop 5,837</div>`)[0];
+                popup_aa1138b3f92069e8cd5ae32530e71da2.setContent(html_498d1ca3e88a5c5c5ca8be6a519a35d8);
+            
+        
+
+        circle_marker_aeca0a6987e5d190318b4aa0e819c282.bindPopup(popup_aa1138b3f92069e8cd5ae32530e71da2)
+        ;
+
+        
+    
+    
+            var circle_marker_cc79373e0e64d9b8b2d840948a76f28d = L.circleMarker(
+                [45.5918514, 11.8059588],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.060509362393883, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_27001a575e29caefa71bc87e31b8236a = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_85c4c8e6a36ba31184441bf829ca24df = $(`<div id="html_85c4c8e6a36ba31184441bf829ca24df" style="width: 100.0%; height: 100.0%;">San Giorgio in Bosco (IT) — pop 5,834</div>`)[0];
+                popup_27001a575e29caefa71bc87e31b8236a.setContent(html_85c4c8e6a36ba31184441bf829ca24df);
+            
+        
+
+        circle_marker_cc79373e0e64d9b8b2d840948a76f28d.bindPopup(popup_27001a575e29caefa71bc87e31b8236a)
+        ;
+
+        
+    
+    
+            var circle_marker_1a73c3f41ca5e917c799b58d33bf17e1 = L.circleMarker(
+                [45.92125, 11.93109],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.059455716780059, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_a325e3215415f7fc233017471f8158c6 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_84d19b59543d0238fa5dfe130468484c = $(`<div id="html_84d19b59543d0238fa5dfe130468484c" style="width: 100.0%; height: 100.0%;">Setteville (IT) — pop 5,820</div>`)[0];
+                popup_a325e3215415f7fc233017471f8158c6.setContent(html_84d19b59543d0238fa5dfe130468484c);
+            
+        
+
+        circle_marker_1a73c3f41ca5e917c799b58d33bf17e1.bindPopup(popup_a325e3215415f7fc233017471f8158c6)
+        ;
+
+        
+    
+    
+            var circle_marker_1ba1a1b1a8bcabbc4d08a4cc9a3fbeec = L.circleMarker(
+                [45.62878, 12.23671],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.05795050876031, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_fdca7ff52c58e53b543264a49f5fa0a1 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_e179797c7ff76276e5a2fc9eef8acb95 = $(`<div id="html_e179797c7ff76276e5a2fc9eef8acb95" style="width: 100.0%; height: 100.0%;">Frescada (IT) — pop 5,800</div>`)[0];
+                popup_fdca7ff52c58e53b543264a49f5fa0a1.setContent(html_e179797c7ff76276e5a2fc9eef8acb95);
+            
+        
+
+        circle_marker_1ba1a1b1a8bcabbc4d08a4cc9a3fbeec.bindPopup(popup_fdca7ff52c58e53b543264a49f5fa0a1)
+        ;
+
+        
+    
+    
+            var circle_marker_22c8e279693fcad4f86314e7c1ccf2f8 = L.circleMarker(
+                [45.8747312, 12.1331619],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.0578752483593235, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_28844f99970ed613634737890e4e9b27 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_7dd577235a3ca312ecdca4e14c1debc5 = $(`<div id="html_7dd577235a3ca312ecdca4e14c1debc5" style="width: 100.0%; height: 100.0%;">Sernaglia della Battaglia (IT) — pop 5,799</div>`)[0];
+                popup_28844f99970ed613634737890e4e9b27.setContent(html_7dd577235a3ca312ecdca4e14c1debc5);
+            
+        
+
+        circle_marker_22c8e279693fcad4f86314e7c1ccf2f8.bindPopup(popup_28844f99970ed613634737890e4e9b27)
+        ;
+
+        
+    
+    
+            var circle_marker_3dc7e5981b765538b9e9a9a552eb8569 = L.circleMarker(
+                [45.95531, 13.46683],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.0575742067553735, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_1a52a5ec56c36dd6bfcfb9a887101ea1 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_89f547dec96604531e66e43977981c51 = $(`<div id="html_89f547dec96604531e66e43977981c51" style="width: 100.0%; height: 100.0%;">Cormons (IT) — pop 5,795</div>`)[0];
+                popup_1a52a5ec56c36dd6bfcfb9a887101ea1.setContent(html_89f547dec96604531e66e43977981c51);
+            
+        
+
+        circle_marker_3dc7e5981b765538b9e9a9a552eb8569.bindPopup(popup_1a52a5ec56c36dd6bfcfb9a887101ea1)
+        ;
+
+        
+    
+    
+            var circle_marker_2b6fa19f2b21b805b53c326b8b2398d2 = L.circleMarker(
+                [46.8963235, 11.4319398],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.056821602745499, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_b10e5b0832ddbe276af36f2bde4d2506 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_f7699145464eeba26ad90da50f7f00e1 = $(`<div id="html_f7699145464eeba26ad90da50f7f00e1" style="width: 100.0%; height: 100.0%;">Sterzing - Vipiteno (IT) — pop 5,785</div>`)[0];
+                popup_b10e5b0832ddbe276af36f2bde4d2506.setContent(html_f7699145464eeba26ad90da50f7f00e1);
+            
+        
+
+        circle_marker_2b6fa19f2b21b805b53c326b8b2398d2.bindPopup(popup_b10e5b0832ddbe276af36f2bde4d2506)
+        ;
+
+        
+    
+    
+            var circle_marker_eb6874a1ac4e7906bd43de2e2e91bd32 = L.circleMarker(
+                [45.63605, 12.25409],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.0566710819435245, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_42cb204d39026a12ab9bd707de876a2b = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_c4d8311031f9129f9fc891c97360394b = $(`<div id="html_c4d8311031f9129f9fc891c97360394b" style="width: 100.0%; height: 100.0%;">Dosson (IT) — pop 5,783</div>`)[0];
+                popup_42cb204d39026a12ab9bd707de876a2b.setContent(html_c4d8311031f9129f9fc891c97360394b);
+            
+        
+
+        circle_marker_eb6874a1ac4e7906bd43de2e2e91bd32.bindPopup(popup_42cb204d39026a12ab9bd707de876a2b)
+        ;
+
+        
+    
+    
+            var circle_marker_f9a8a8a8c65644aff7541b186427dc9b = L.circleMarker(
+                [47.25, 11.41667],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.055767957131676, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_251a7fb316f124a36c00df4ebf2dccfb = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_f6ed6f56b8ccf12be722e7c071ba0056 = $(`<div id="html_f6ed6f56b8ccf12be722e7c071ba0056" style="width: 100.0%; height: 100.0%;">Amras (AT) — pop 5,771</div>`)[0];
+                popup_251a7fb316f124a36c00df4ebf2dccfb.setContent(html_f6ed6f56b8ccf12be722e7c071ba0056);
+            
+        
+
+        circle_marker_f9a8a8a8c65644aff7541b186427dc9b.bindPopup(popup_251a7fb316f124a36c00df4ebf2dccfb)
+        ;
+
+        
+    
+    
+            var circle_marker_a044a2cbc7a6f72869e910b456960f17 = L.circleMarker(
+                [47.53333, 9.75],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.053961707507978, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_ca8ef319a95e64bed867242ff0d44732 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_9a4b563fabcc4ac44fbc424655ca805a = $(`<div id="html_9a4b563fabcc4ac44fbc424655ca805a" style="width: 100.0%; height: 100.0%;">Lochau (AT) — pop 5,747</div>`)[0];
+                popup_ca8ef319a95e64bed867242ff0d44732.setContent(html_9a4b563fabcc4ac44fbc424655ca805a);
+            
+        
+
+        circle_marker_a044a2cbc7a6f72869e910b456960f17.bindPopup(popup_ca8ef319a95e64bed867242ff0d44732)
+        ;
+
+        
+    
+    
+            var circle_marker_68172eb5c21f2089688e2c9639f0540f = L.circleMarker(
+                [45.45375, 12.45729],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.053209103498103, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_a7db253848aa0b0ceaff06fdcc13efd6 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_b724fc7dab56a313f5dee4be9acb1746 = $(`<div id="html_b724fc7dab56a313f5dee4be9acb1746" style="width: 100.0%; height: 100.0%;">Ca' Savio (IT) — pop 5,737</div>`)[0];
+                popup_a7db253848aa0b0ceaff06fdcc13efd6.setContent(html_b724fc7dab56a313f5dee4be9acb1746);
+            
+        
+
+        circle_marker_68172eb5c21f2089688e2c9639f0540f.bindPopup(popup_a7db253848aa0b0ceaff06fdcc13efd6)
+        ;
+
+        
+    
+    
+            var circle_marker_d17c58ec640c41fcd0263fdb7d564b0d = L.circleMarker(
+                [46.6280688, 10.7734765],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.052908061894154, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_d3b5034e71faba171fdb3c3f02f84bed = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_1bd04ff8e9f13873e7a09bce8cb164a4 = $(`<div id="html_1bd04ff8e9f13873e7a09bce8cb164a4" style="width: 100.0%; height: 100.0%;">Schlanders - Silandro (IT) — pop 5,733</div>`)[0];
+                popup_d3b5034e71faba171fdb3c3f02f84bed.setContent(html_1bd04ff8e9f13873e7a09bce8cb164a4);
+            
+        
+
+        circle_marker_d17c58ec640c41fcd0263fdb7d564b0d.bindPopup(popup_d3b5034e71faba171fdb3c3f02f84bed)
+        ;
+
+        
+    
+    
+            var circle_marker_b7c66a6a0bd43b3c1896ee249f677986 = L.circleMarker(
+                [45.8319666, 12.0080268],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.052682280691192, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_36aef47875380dfe4ceb719c589e2ce0 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_cdd7fd654d08d60a5e83575e4fad6800 = $(`<div id="html_cdd7fd654d08d60a5e83575e4fad6800" style="width: 100.0%; height: 100.0%;">Cornuda (IT) — pop 5,730</div>`)[0];
+                popup_36aef47875380dfe4ceb719c589e2ce0.setContent(html_cdd7fd654d08d60a5e83575e4fad6800);
+            
+        
+
+        circle_marker_b7c66a6a0bd43b3c1896ee249f677986.bindPopup(popup_36aef47875380dfe4ceb719c589e2ce0)
+        ;
+
+        
+    
+    
+            var circle_marker_d729ec5e562d695b34651ae92881e0cd = L.circleMarker(
+                [47.4891092, 10.7187955],
+                {"bubblingMouseEvents": true, "color": "blue", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "blue", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.05185441628033, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_93d85a9853de512e43f9643a30788270 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_3f4864e887788168ef37572a450fe1ad = $(`<div id="html_3f4864e887788168ef37572a450fe1ad" style="width: 100.0%; height: 100.0%;">Reutte (DE) — pop 5,719</div>`)[0];
+                popup_93d85a9853de512e43f9643a30788270.setContent(html_3f4864e887788168ef37572a450fe1ad);
+            
+        
+
+        circle_marker_d729ec5e562d695b34651ae92881e0cd.bindPopup(popup_93d85a9853de512e43f9643a30788270)
+        ;
+
+        
+    
+    
+            var circle_marker_3935a378a79ff9f3124a575938514094 = L.circleMarker(
+                [45.83667, 12.03361],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.051101812270455, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_6581d3c6685b52b78f4f9325da1509ae = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_6df9f222162687fff99b1c467c279f6f = $(`<div id="html_6df9f222162687fff99b1c467c279f6f" style="width: 100.0%; height: 100.0%;">Crocetta del Montello (IT) — pop 5,709</div>`)[0];
+                popup_6581d3c6685b52b78f4f9325da1509ae.setContent(html_6df9f222162687fff99b1c467c279f6f);
+            
+        
+
+        circle_marker_3935a378a79ff9f3124a575938514094.bindPopup(popup_6581d3c6685b52b78f4f9325da1509ae)
+        ;
+
+        
+    
+    
+            var circle_marker_7d3f133c17d07e150adca8ac3761d565 = L.circleMarker(
+                [46.18752, 13.06162],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.049671864651695, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_6458056f55caa6bbb53795a0760c666d = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_52283ed398acc33937c9e7bb422770be = $(`<div id="html_52283ed398acc33937c9e7bb422770be" style="width: 100.0%; height: 100.0%;">Majano (IT) — pop 5,690</div>`)[0];
+                popup_6458056f55caa6bbb53795a0760c666d.setContent(html_52283ed398acc33937c9e7bb422770be);
+            
+        
+
+        circle_marker_7d3f133c17d07e150adca8ac3761d565.bindPopup(popup_6458056f55caa6bbb53795a0760c666d)
+        ;
+
+        
+    
+    
+            var circle_marker_b255d532b474cbe686a3a61d7a0084cd = L.circleMarker(
+                [47.54208, 10.25846],
+                {"bubblingMouseEvents": true, "color": "blue", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "blue", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.044779938587513, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_2a86bf168444ce1c06633e56ee14483b = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_b398f4a23ae83136ab2acc487f514d25 = $(`<div id="html_b398f4a23ae83136ab2acc487f514d25" style="width: 100.0%; height: 100.0%;">Blaichach (DE) — pop 5,625</div>`)[0];
+                popup_2a86bf168444ce1c06633e56ee14483b.setContent(html_b398f4a23ae83136ab2acc487f514d25);
+            
+        
+
+        circle_marker_b255d532b474cbe686a3a61d7a0084cd.bindPopup(popup_2a86bf168444ce1c06633e56ee14483b)
+        ;
+
+        
+    
+    
+            var circle_marker_2b416213b54e3c8806cc138060ebf9a6 = L.circleMarker(
+                [46.16058, 13.21566],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.042145824552954, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_1cca65c924b45c3a0d43062f2d35c478 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_d2aac65326056cf4a7ede333b483523e = $(`<div id="html_d2aac65326056cf4a7ede333b483523e" style="width: 100.0%; height: 100.0%;">Tricesimo (IT) — pop 5,590</div>`)[0];
+                popup_1cca65c924b45c3a0d43062f2d35c478.setContent(html_d2aac65326056cf4a7ede333b483523e);
+            
+        
+
+        circle_marker_2b416213b54e3c8806cc138060ebf9a6.bindPopup(popup_1cca65c924b45c3a0d43062f2d35c478)
+        ;
+
+        
+    
+    
+            var circle_marker_a0479b36e39eb8673cb6f3b9f02d88aa = L.circleMarker(
+                [45.89947, 12.54178],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.041769522548016, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_149f5d469de90b32613d7df01e012abc = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_917ef9cb68b3c33c0e7e8c8eb7cd4b2f = $(`<div id="html_917ef9cb68b3c33c0e7e8c8eb7cd4b2f" style="width: 100.0%; height: 100.0%;">Brugnera (IT) — pop 5,585</div>`)[0];
+                popup_149f5d469de90b32613d7df01e012abc.setContent(html_917ef9cb68b3c33c0e7e8c8eb7cd4b2f);
+            
+        
+
+        circle_marker_a0479b36e39eb8673cb6f3b9f02d88aa.bindPopup(popup_149f5d469de90b32613d7df01e012abc)
+        ;
+
+        
+    
+    
+            var circle_marker_f8c88cc3ebcf488ccd93fad0d74f3b49 = L.circleMarker(
+                [46.0855837, 13.3243217],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.0389096273104945, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_e22250d4e43693b3c3553efdeba85762 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_6112c75fdc0379f96ca411809415b39d = $(`<div id="html_6112c75fdc0379f96ca411809415b39d" style="width: 100.0%; height: 100.0%;">Remanzacco / Remanzâs (IT) — pop 5,547</div>`)[0];
+                popup_e22250d4e43693b3c3553efdeba85762.setContent(html_6112c75fdc0379f96ca411809415b39d);
+            
+        
+
+        circle_marker_f8c88cc3ebcf488ccd93fad0d74f3b49.bindPopup(popup_e22250d4e43693b3c3553efdeba85762)
+        ;
+
+        
+    
+    
+            var circle_marker_0c853fa6c1cb8e6758b655cde161e11b = L.circleMarker(
+                [46.99623, 11.97988],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.036651815280872, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_604a2d0661e66c065f5f5573415c4808 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_8941037bb505a8f81b16d4a22df371c8 = $(`<div id="html_8941037bb505a8f81b16d4a22df371c8" style="width: 100.0%; height: 100.0%;">Valle Aurina - Ahrntal (IT) — pop 5,517</div>`)[0];
+                popup_604a2d0661e66c065f5f5573415c4808.setContent(html_8941037bb505a8f81b16d4a22df371c8);
+            
+        
+
+        circle_marker_0c853fa6c1cb8e6758b655cde161e11b.bindPopup(popup_604a2d0661e66c065f5f5573415c4808)
+        ;
+
+        
+    
+    
+            var circle_marker_d59a6f6703b60e8834e824398b41d091 = L.circleMarker(
+                [45.5852852, 11.3944971],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.034017701246312, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_b96dae2e25b230dd40c980e6d04ee72b = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_978bbd5cab4de02833ff557c2ca8e635 = $(`<div id="html_978bbd5cab4de02833ff557c2ca8e635" style="width: 100.0%; height: 100.0%;">Castelgomberto (IT) — pop 5,482</div>`)[0];
+                popup_b96dae2e25b230dd40c980e6d04ee72b.setContent(html_978bbd5cab4de02833ff557c2ca8e635);
+            
+        
+
+        circle_marker_d59a6f6703b60e8834e824398b41d091.bindPopup(popup_b96dae2e25b230dd40c980e6d04ee72b)
+        ;
+
+        
+    
+    
+            var circle_marker_110eee2c9fb61b467645ffd084ffee4f = L.circleMarker(
+                [45.9963174, 13.3041373],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.033641399241375, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_df0d3834bcc5073c132a2ee8a5fd3b5f = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_0078c5c91d3c685da0e907b15074f895 = $(`<div id="html_0078c5c91d3c685da0e907b15074f895" style="width: 100.0%; height: 100.0%;">Pavia di Udine / Pavie (IT) — pop 5,477</div>`)[0];
+                popup_df0d3834bcc5073c132a2ee8a5fd3b5f.setContent(html_0078c5c91d3c685da0e907b15074f895);
+            
+        
+
+        circle_marker_110eee2c9fb61b467645ffd084ffee4f.bindPopup(popup_df0d3834bcc5073c132a2ee8a5fd3b5f)
+        ;
+
+        
+    
+    
+            var circle_marker_960d30d4dba61e61b0a434afcc5a19c4 = L.circleMarker(
+                [45.7188875, 11.3086976],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.033566138840388, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_a0348fde8d75c3ff518c21b020151257 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_75e74772eb3bf6213a3fbe7606fe8f36 = $(`<div id="html_75e74772eb3bf6213a3fbe7606fe8f36" style="width: 100.0%; height: 100.0%;">Torrebelvicino (IT) — pop 5,476</div>`)[0];
+                popup_a0348fde8d75c3ff518c21b020151257.setContent(html_75e74772eb3bf6213a3fbe7606fe8f36);
+            
+        
+
+        circle_marker_960d30d4dba61e61b0a434afcc5a19c4.bindPopup(popup_a0348fde8d75c3ff518c21b020151257)
+        ;
+
+        
+    
+    
+            var circle_marker_38e4956deadfb21816c632f8e8d38ac2 = L.circleMarker(
+                [46.60806, 13.83153],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.033415618038413, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_17bd61e87c56e3a789fbc2a0b52cc40e = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_045d9bc46983681728e8a530252061e3 = $(`<div id="html_045d9bc46983681728e8a530252061e3" style="width: 100.0%; height: 100.0%;">Völkendorf (AT) — pop 5,474</div>`)[0];
+                popup_17bd61e87c56e3a789fbc2a0b52cc40e.setContent(html_045d9bc46983681728e8a530252061e3);
+            
+        
+
+        circle_marker_38e4956deadfb21816c632f8e8d38ac2.bindPopup(popup_17bd61e87c56e3a789fbc2a0b52cc40e)
+        ;
+
+        
+    
+    
+            var circle_marker_af2f105ae368ab703769fecc03a0a7c1 = L.circleMarker(
+                [45.8313331, 12.4675458],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.033189836835451, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_0db26c303b21d9312e2dc85c693a8fc1 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_1ed673d16431aaa4fbb11de7b19e555d = $(`<div id="html_1ed673d16431aaa4fbb11de7b19e555d" style="width: 100.0%; height: 100.0%;">Fontanelle (IT) — pop 5,471</div>`)[0];
+                popup_0db26c303b21d9312e2dc85c693a8fc1.setContent(html_1ed673d16431aaa4fbb11de7b19e555d);
+            
+        
+
+        circle_marker_af2f105ae368ab703769fecc03a0a7c1.bindPopup(popup_0db26c303b21d9312e2dc85c693a8fc1)
+        ;
+
+        
+    
+    
+            var circle_marker_b7e026985db317bc7a7977a4f7d7fc67 = L.circleMarker(
+                [46.06759, 12.58324],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.032738274429526, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_f1d0a71d86a4220d729d1a25e5ea34d2 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_ecfcb89bcf617040be0d7b3c1e9d975c = $(`<div id="html_ecfcb89bcf617040be0d7b3c1e9d975c" style="width: 100.0%; height: 100.0%;">Aviano-Castello (IT) — pop 5,465</div>`)[0];
+                popup_f1d0a71d86a4220d729d1a25e5ea34d2.setContent(html_ecfcb89bcf617040be0d7b3c1e9d975c);
+            
+        
+
+        circle_marker_b7e026985db317bc7a7977a4f7d7fc67.bindPopup(popup_f1d0a71d86a4220d729d1a25e5ea34d2)
+        ;
+
+        
+    
+    
+            var circle_marker_a2b1a98ae9cfff6662739fd8a9f9986f = L.circleMarker(
+                [45.6007102, 11.6221007],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.031985670419652, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_518591e08bfcfe539d8da908fe8c76b1 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_e49bc8dc6a13c7e9a62da7a1a28f2715 = $(`<div id="html_e49bc8dc6a13c7e9a62da7a1a28f2715" style="width: 100.0%; height: 100.0%;">Bolzano Vicentino (IT) — pop 5,455</div>`)[0];
+                popup_518591e08bfcfe539d8da908fe8c76b1.setContent(html_e49bc8dc6a13c7e9a62da7a1a28f2715);
+            
+        
+
+        circle_marker_a2b1a98ae9cfff6662739fd8a9f9986f.bindPopup(popup_518591e08bfcfe539d8da908fe8c76b1)
+        ;
+
+        
+    
+    
+            var circle_marker_d1c91b46e27dd98372b40c9eda03f302 = L.circleMarker(
+                [46.04667, 13.1878],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.031383587211753, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_f5de5220e3cca0a15bdbfaf4f96ae9bc = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_bde49bf94f8746037fb08cc26ec0d43f = $(`<div id="html_bde49bf94f8746037fb08cc26ec0d43f" style="width: 100.0%; height: 100.0%;">Pasian di Prato (IT) — pop 5,447</div>`)[0];
+                popup_f5de5220e3cca0a15bdbfaf4f96ae9bc.setContent(html_bde49bf94f8746037fb08cc26ec0d43f);
+            
+        
+
+        circle_marker_d1c91b46e27dd98372b40c9eda03f302.bindPopup(popup_f5de5220e3cca0a15bdbfaf4f96ae9bc)
+        ;
+
+        
+    
+    
+            var circle_marker_820a15c18a7818fece7d3a8a58e99db9 = L.circleMarker(
+                [47.28333, 11.4],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.030480462399904, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_c5bbacb33bc8654dd256df9a1adb0999 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_9dcf6d0c08d5cbdf3a36d9a9d7594f2e = $(`<div id="html_9dcf6d0c08d5cbdf3a36d9a9d7594f2e" style="width: 100.0%; height: 100.0%;">Mühlau (AT) — pop 5,435</div>`)[0];
+                popup_c5bbacb33bc8654dd256df9a1adb0999.setContent(html_9dcf6d0c08d5cbdf3a36d9a9d7594f2e);
+            
+        
+
+        circle_marker_820a15c18a7818fece7d3a8a58e99db9.bindPopup(popup_c5bbacb33bc8654dd256df9a1adb0999)
+        ;
+
+        
+    
+    
+            var circle_marker_a49906372ebb4f622cd0abcf392d7ed1 = L.circleMarker(
+                [46.0977183, 13.1347959],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.028222650370282, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_ba278a06ce2b48cdd4c7f94f7f321dde = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_3e66c5f238352abf8138155a034ade0b = $(`<div id="html_3e66c5f238352abf8138155a034ade0b" style="width: 100.0%; height: 100.0%;">Martignacco / Martignà (IT) — pop 5,405</div>`)[0];
+                popup_ba278a06ce2b48cdd4c7f94f7f321dde.setContent(html_3e66c5f238352abf8138155a034ade0b);
+            
+        
+
+        circle_marker_a49906372ebb4f622cd0abcf392d7ed1.bindPopup(popup_ba278a06ce2b48cdd4c7f94f7f321dde)
+        ;
+
+        
+    
+    
+            var circle_marker_ae3fa44109f442dd5b0ff48867f4e41b = L.circleMarker(
+                [45.6511748, 11.4940528],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.027018483954483, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_2aa4217bc572313199c5e2de3089a557 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_016e9c929fc83e15460bf50ce5d1d27b = $(`<div id="html_016e9c929fc83e15460bf50ce5d1d27b" style="width: 100.0%; height: 100.0%;">Villaverla (IT) — pop 5,389</div>`)[0];
+                popup_2aa4217bc572313199c5e2de3089a557.setContent(html_016e9c929fc83e15460bf50ce5d1d27b);
+            
+        
+
+        circle_marker_ae3fa44109f442dd5b0ff48867f4e41b.bindPopup(popup_2aa4217bc572313199c5e2de3089a557)
+        ;
+
+        
+    
+    
+            var circle_marker_f876824844da1ceb233f1a59954192dc = L.circleMarker(
+                [47.597344, 11.0640664],
+                {"bubblingMouseEvents": true, "color": "blue", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "blue", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.026265879944608, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_370492007429cc8187e86ec2e1aa8d38 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_d16e8ffd1661fbba47ceb4e1e237ca71 = $(`<div id="html_d16e8ffd1661fbba47ceb4e1e237ca71" style="width: 100.0%; height: 100.0%;">Oberammergau (DE) — pop 5,379</div>`)[0];
+                popup_370492007429cc8187e86ec2e1aa8d38.setContent(html_d16e8ffd1661fbba47ceb4e1e237ca71);
+            
+        
+
+        circle_marker_f876824844da1ceb233f1a59954192dc.bindPopup(popup_370492007429cc8187e86ec2e1aa8d38)
+        ;
+
+        
+    
+    
+            var circle_marker_1c8990994ab5befc1ef6e676da12818d = L.circleMarker(
+                [45.544396, 11.810404],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.025663796736709, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_642c0e2cdb62367adf845f07c4d03c3c = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_1323fd43319b3f1c5e06f0fee0ac96dd = $(`<div id="html_1323fd43319b3f1c5e06f0fee0ac96dd" style="width: 100.0%; height: 100.0%;">Campo San Martino (IT) — pop 5,371</div>`)[0];
+                popup_642c0e2cdb62367adf845f07c4d03c3c.setContent(html_1323fd43319b3f1c5e06f0fee0ac96dd);
+            
+        
+
+        circle_marker_1c8990994ab5befc1ef6e676da12818d.bindPopup(popup_642c0e2cdb62367adf845f07c4d03c3c)
+        ;
+
+        
+    
+    
+            var circle_marker_653af6d5d76384b6b7e58cc7fda25425 = L.circleMarker(
+                [47.4504996, 12.1558791],
+                {"bubblingMouseEvents": true, "color": "blue", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "blue", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.025212234330785, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_080aab56faefaf978ab8a15c0588ee0c = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_89a0d7bf44c0ab77a460a2699c10f08d = $(`<div id="html_89a0d7bf44c0ab77a460a2699c10f08d" style="width: 100.0%; height: 100.0%;">Hopfgarten im Brixental (DE) — pop 5,365</div>`)[0];
+                popup_080aab56faefaf978ab8a15c0588ee0c.setContent(html_89a0d7bf44c0ab77a460a2699c10f08d);
+            
+        
+
+        circle_marker_653af6d5d76384b6b7e58cc7fda25425.bindPopup(popup_080aab56faefaf978ab8a15c0588ee0c)
+        ;
+
+        
+    
+    
+            var circle_marker_6f8fbbca72adad4af161370ae5a19228 = L.circleMarker(
+                [46.265786, 12.2999366],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.02476067192486, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_31c1458ed7b5dd9f375ce8ff6bc42da0 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_d30500c025ce94b9e137daafd93bb083 = $(`<div id="html_d30500c025ce94b9e137daafd93bb083" style="width: 100.0%; height: 100.0%;">Longarone / Longaron (IT) — pop 5,359</div>`)[0];
+                popup_31c1458ed7b5dd9f375ce8ff6bc42da0.setContent(html_d30500c025ce94b9e137daafd93bb083);
+            
+        
+
+        circle_marker_6f8fbbca72adad4af161370ae5a19228.bindPopup(popup_31c1458ed7b5dd9f375ce8ff6bc42da0)
+        ;
+
+        
+    
+    
+            var circle_marker_3d21fd994e44f0adb2d1dfac2e950e80 = L.circleMarker(
+                [46.89313, 11.42961],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.024534890721898, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_59f965cf008480d50f9b3044dd52b807 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_05d513a8f0ea484bff30b8da952c2023 = $(`<div id="html_05d513a8f0ea484bff30b8da952c2023" style="width: 100.0%; height: 100.0%;">Sterzing (IT) — pop 5,356</div>`)[0];
+                popup_59f965cf008480d50f9b3044dd52b807.setContent(html_05d513a8f0ea484bff30b8da952c2023);
+            
+        
+
+        circle_marker_3d21fd994e44f0adb2d1dfac2e950e80.bindPopup(popup_59f965cf008480d50f9b3044dd52b807)
+        ;
+
+        
+    
+    
+            var circle_marker_6e6e92d6ee622859cd42ab59d52cb562 = L.circleMarker(
+                [45.9054635, 13.3099318],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.024233849117948, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_05fb7d7f54659a238c7d843641f89a3e = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_210e1f7e5413de43cd2d5deee13064ad = $(`<div id="html_210e1f7e5413de43cd2d5deee13064ad" style="width: 100.0%; height: 100.0%;">Palmanova (IT) — pop 5,352</div>`)[0];
+                popup_05fb7d7f54659a238c7d843641f89a3e.setContent(html_210e1f7e5413de43cd2d5deee13064ad);
+            
+        
+
+        circle_marker_6e6e92d6ee622859cd42ab59d52cb562.bindPopup(popup_05fb7d7f54659a238c7d843641f89a3e)
+        ;
+
+        
+    
+    
+            var circle_marker_d1330ac2d6cc116ec45dcddde9551fd1 = L.circleMarker(
+                [45.76072, 11.00458],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.0226533806972125, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_ebb140b5609265f144c5322020b28619 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_bc50f3cd208d9148273d3957c712fb8d = $(`<div id="html_bc50f3cd208d9148273d3957c712fb8d" style="width: 100.0%; height: 100.0%;">Ala (IT) — pop 5,331</div>`)[0];
+                popup_ebb140b5609265f144c5322020b28619.setContent(html_bc50f3cd208d9148273d3957c712fb8d);
+            
+        
+
+        circle_marker_d1330ac2d6cc116ec45dcddde9551fd1.bindPopup(popup_ebb140b5609265f144c5322020b28619)
+        ;
+
+        
+    
+    
+            var circle_marker_2a66eb692a75e8965aa86c71a663b17f = L.circleMarker(
+                [46.00847, 12.61938],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.0220512974893134, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_363c66de2b3bc1895bf9cd98730fd46c = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_50b20510cede7c48a241036bd0f5356e = $(`<div id="html_50b20510cede7c48a241036bd0f5356e" style="width: 100.0%; height: 100.0%;">Roveredo in Piano (IT) — pop 5,323</div>`)[0];
+                popup_363c66de2b3bc1895bf9cd98730fd46c.setContent(html_50b20510cede7c48a241036bd0f5356e);
+            
+        
+
+        circle_marker_2a66eb692a75e8965aa86c71a663b17f.bindPopup(popup_363c66de2b3bc1895bf9cd98730fd46c)
+        ;
+
+        
+    
+    
+            var circle_marker_636803bf95668978bfafb4b9000ea2a6 = L.circleMarker(
+                [47.2307532, 11.279297],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.021674995484376, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_2709d8ef85bcbbcbe9074b4f1fc4ef50 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_1452bad9508ef65df71580f38de6217e = $(`<div id="html_1452bad9508ef65df71580f38de6217e" style="width: 100.0%; height: 100.0%;">Axams (AT) — pop 5,318</div>`)[0];
+                popup_2709d8ef85bcbbcbe9074b4f1fc4ef50.setContent(html_1452bad9508ef65df71580f38de6217e);
+            
+        
+
+        circle_marker_636803bf95668978bfafb4b9000ea2a6.bindPopup(popup_2709d8ef85bcbbcbe9074b4f1fc4ef50)
+        ;
+
+        
+    
+    
+            var circle_marker_b383cf63b73a454dbdd588f00e0eb4f2 = L.circleMarker(
+                [47.3422672, 11.683269],
+                {"bubblingMouseEvents": true, "color": "blue", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "blue", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.019040881449817, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_c766d8af799807e3b5893605af5a9cbb = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_d6bd1e01414e6a1e92770e30d76373cc = $(`<div id="html_d6bd1e01414e6a1e92770e30d76373cc" style="width: 100.0%; height: 100.0%;">Vomp (DE) — pop 5,283</div>`)[0];
+                popup_c766d8af799807e3b5893605af5a9cbb.setContent(html_d6bd1e01414e6a1e92770e30d76373cc);
+            
+        
+
+        circle_marker_b383cf63b73a454dbdd588f00e0eb4f2.bindPopup(popup_c766d8af799807e3b5893605af5a9cbb)
+        ;
+
+        
+    
+    
+            var circle_marker_b20846e3084fde177974b642ebf29a93 = L.circleMarker(
+                [46.1181791, 13.2987971],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.0185140586429045, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_42705043480378364626600bbba5da43 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_f2f711f8ab406043327f1af03afa55ed = $(`<div id="html_f2f711f8ab406043327f1af03afa55ed" style="width: 100.0%; height: 100.0%;">Povoletto / Paulêt (IT) — pop 5,276</div>`)[0];
+                popup_42705043480378364626600bbba5da43.setContent(html_f2f711f8ab406043327f1af03afa55ed);
+            
+        
+
+        circle_marker_b20846e3084fde177974b642ebf29a93.bindPopup(popup_42705043480378364626600bbba5da43)
+        ;
+
+        
+    
+    
+            var circle_marker_06f59077d463b995b6506d6f4963ac10 = L.circleMarker(
+                [45.7372986, 11.3903211],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.0182130170389545, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_7075599190f94ba44f9f2ac8bf869dda = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_5b1e694bda4423f8db5cb75ef82525f8 = $(`<div id="html_5b1e694bda4423f8db5cb75ef82525f8" style="width: 100.0%; height: 100.0%;">Santorso (IT) — pop 5,272</div>`)[0];
+                popup_7075599190f94ba44f9f2ac8bf869dda.setContent(html_5b1e694bda4423f8db5cb75ef82525f8);
+            
+        
+
+        circle_marker_06f59077d463b995b6506d6f4963ac10.bindPopup(popup_7075599190f94ba44f9f2ac8bf869dda)
+        ;
+
+        
+    
+    
+            var circle_marker_893ae0aefb4e2110eb4a507bd342aaf8 = L.circleMarker(
+                [45.51508, 12.2079],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.0173098922271055, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_1eeabd111998e5eac188242e18c924ab = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_fbbe0e8410d5125af371ffb3e4606aa4 = $(`<div id="html_fbbe0e8410d5125af371ffb3e4606aa4" style="width: 100.0%; height: 100.0%;">Zelarino (IT) — pop 5,260</div>`)[0];
+                popup_1eeabd111998e5eac188242e18c924ab.setContent(html_fbbe0e8410d5125af371ffb3e4606aa4);
+            
+        
+
+        circle_marker_893ae0aefb4e2110eb4a507bd342aaf8.bindPopup(popup_1eeabd111998e5eac188242e18c924ab)
+        ;
+
+        
+    
+    
+            var circle_marker_dc75ced8f1562fc47115134e2a872f6a = L.circleMarker(
+                [45.81379, 10.06995],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.016933590222169, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_17b29000674efbe3041856b8985ae199 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_b073a71be51f2a95b6b7245dbb1a3ac5 = $(`<div id="html_b073a71be51f2a95b6b7245dbb1a3ac5" style="width: 100.0%; height: 100.0%;">Lovere (IT) — pop 5,255</div>`)[0];
+                popup_17b29000674efbe3041856b8985ae199.setContent(html_b073a71be51f2a95b6b7245dbb1a3ac5);
+            
+        
+
+        circle_marker_dc75ced8f1562fc47115134e2a872f6a.bindPopup(popup_17b29000674efbe3041856b8985ae199)
+        ;
+
+        
+    
+    
+            var circle_marker_7249cc670db336b8fa1d489ef7ed1912 = L.circleMarker(
+                [46.62244, 13.84715],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.0167078090192065, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_2df361f357c5a5dd254b5adaed6003c9 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_96635e6a6f202bbdc23677da00a18aa7 = $(`<div id="html_96635e6a6f202bbdc23677da00a18aa7" style="width: 100.0%; height: 100.0%;">Lind (AT) — pop 5,252</div>`)[0];
+                popup_2df361f357c5a5dd254b5adaed6003c9.setContent(html_96635e6a6f202bbdc23677da00a18aa7);
+            
+        
+
+        circle_marker_7249cc670db336b8fa1d489ef7ed1912.bindPopup(popup_2df361f357c5a5dd254b5adaed6003c9)
+        ;
+
+        
+    
+    
+            var circle_marker_67851891f12af484d6214bcaf8505337 = L.circleMarker(
+                [45.80777, 10.11023],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.016406767415257, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_c829ba6a7e078b91a5e129410952d922 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_06bfdb7fea6610d123ec85cd4d560cec = $(`<div id="html_06bfdb7fea6610d123ec85cd4d560cec" style="width: 100.0%; height: 100.0%;">Pisogne (IT) — pop 5,248</div>`)[0];
+                popup_c829ba6a7e078b91a5e129410952d922.setContent(html_06bfdb7fea6610d123ec85cd4d560cec);
+            
+        
+
+        circle_marker_67851891f12af484d6214bcaf8505337.bindPopup(popup_c829ba6a7e078b91a5e129410952d922)
+        ;
+
+        
+    
+    
+            var circle_marker_8f2bf1bb9637979185ba376fd88f0689 = L.circleMarker(
+                [47.44539, 12.31602],
+                {"bubblingMouseEvents": true, "color": "red", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "red", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.016180986212294, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_3663f374d59727dd6d9a18fad40b706b = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_01c09f57713cb130d2a0a185121b7b73 = $(`<div id="html_01c09f57713cb130d2a0a185121b7b73" style="width: 100.0%; height: 100.0%;">Kirchberg in Tirol (AT) — pop 5,245</div>`)[0];
+                popup_3663f374d59727dd6d9a18fad40b706b.setContent(html_01c09f57713cb130d2a0a185121b7b73);
+            
+        
+
+        circle_marker_8f2bf1bb9637979185ba376fd88f0689.bindPopup(popup_3663f374d59727dd6d9a18fad40b706b)
+        ;
+
+        
+    
+    
+            var circle_marker_5e22934b3cb60f86f207290f03af3ab2 = L.circleMarker(
+                [46.3169161, 11.2725698],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.015202600999458, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_2c432f95fd048ab5b2a88c093d7b5031 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_dc10b491805b58f3035625c13bb79a10 = $(`<div id="html_dc10b491805b58f3035625c13bb79a10" style="width: 100.0%; height: 100.0%;">Neumarkt - Egna (IT) — pop 5,232</div>`)[0];
+                popup_2c432f95fd048ab5b2a88c093d7b5031.setContent(html_dc10b491805b58f3035625c13bb79a10);
+            
+        
+
+        circle_marker_5e22934b3cb60f86f207290f03af3ab2.bindPopup(popup_2c432f95fd048ab5b2a88c093d7b5031)
+        ;
+
+        
+    
+    
+            var circle_marker_89110261c92008d8e4921c7ffc800cb5 = L.circleMarker(
+                [47.4475913, 12.3144495],
+                {"bubblingMouseEvents": true, "color": "blue", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "blue", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.014525257390571, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_7f2da020f866003062c344d745e62be0 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_78e1d53385a7805b09c5edfc5b38d57e = $(`<div id="html_78e1d53385a7805b09c5edfc5b38d57e" style="width: 100.0%; height: 100.0%;">Kirchberg in Tirol (DE) — pop 5,223</div>`)[0];
+                popup_7f2da020f866003062c344d745e62be0.setContent(html_78e1d53385a7805b09c5edfc5b38d57e);
+            
+        
+
+        circle_marker_89110261c92008d8e4921c7ffc800cb5.bindPopup(popup_7f2da020f866003062c344d745e62be0)
+        ;
+
+        
+    
+    
+            var circle_marker_b8b8697870afdf9aa2f7fc43851ba901 = L.circleMarker(
+                [46.00865, 11.12984],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.013847913781684, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_af638e2dd2f4c595d8417b774907a2ac = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_12ba8281fc57f6dfe3a7bedbc888ddb4 = $(`<div id="html_12ba8281fc57f6dfe3a7bedbc888ddb4" style="width: 100.0%; height: 100.0%;">Mattarello (IT) — pop 5,214</div>`)[0];
+                popup_af638e2dd2f4c595d8417b774907a2ac.setContent(html_12ba8281fc57f6dfe3a7bedbc888ddb4);
+            
+        
+
+        circle_marker_b8b8697870afdf9aa2f7fc43851ba901.bindPopup(popup_af638e2dd2f4c595d8417b774907a2ac)
+        ;
+
+        
+    
+    
+            var circle_marker_9a6effe4580b1f54395e1d75971f5783 = L.circleMarker(
+                [45.98843, 13.37674],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.010385935336264, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_a79e638a21bfe762e3a80736b9144e2d = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_9f34e022dd9315378e9bdb562e5b1297 = $(`<div id="html_9f34e022dd9315378e9bdb562e5b1297" style="width: 100.0%; height: 100.0%;">Manzano (IT) — pop 5,168</div>`)[0];
+                popup_a79e638a21bfe762e3a80736b9144e2d.setContent(html_9f34e022dd9315378e9bdb562e5b1297);
+            
+        
+
+        circle_marker_9a6effe4580b1f54395e1d75971f5783.bindPopup(popup_a79e638a21bfe762e3a80736b9144e2d)
+        ;
+
+        
+    
+    
+            var circle_marker_6170ad6e1018030679afd523d68999cb = L.circleMarker(
+                [46.13509, 9.55164],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.007902342103678, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_f4cc7db469781ce966b50704f74bda35 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_6c2c25d9a0c2c1110bb7ca1200aa21dc = $(`<div id="html_6c2c25d9a0c2c1110bb7ca1200aa21dc" style="width: 100.0%; height: 100.0%;">Cosio Valtellino (IT) — pop 5,135</div>`)[0];
+                popup_f4cc7db469781ce966b50704f74bda35.setContent(html_6c2c25d9a0c2c1110bb7ca1200aa21dc);
+            
+        
+
+        circle_marker_6170ad6e1018030679afd523d68999cb.bindPopup(popup_f4cc7db469781ce966b50704f74bda35)
+        ;
+
+        
+    
+    
+            var circle_marker_46fecdb7d84b2ac0868537b231f3a45d = L.circleMarker(
+                [45.85687, 6.61775],
+                {"bubblingMouseEvents": true, "color": "green", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "green", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.007450779697754, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_b8a6377359b026c5ffe55b543ff6462f = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_d9431f832e0873330eb0a8f1176dc9ad = $(`<div id="html_d9431f832e0873330eb0a8f1176dc9ad" style="width: 100.0%; height: 100.0%;">Megève (FR) — pop 5,129</div>`)[0];
+                popup_b8a6377359b026c5ffe55b543ff6462f.setContent(html_d9431f832e0873330eb0a8f1176dc9ad);
+            
+        
+
+        circle_marker_46fecdb7d84b2ac0868537b231f3a45d.bindPopup(popup_b8a6377359b026c5ffe55b543ff6462f)
+        ;
+
+        
+    
+    
+            var circle_marker_b3804490bb9a89d97e4ebbb39cd7da92 = L.circleMarker(
+                [45.9409837, 12.3409719],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.00609609247998, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_caec58f603757c79583d1ef049692a3e = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_4385f5d2de507c55096fa03d5c1b5b3a = $(`<div id="html_4385f5d2de507c55096fa03d5c1b5b3a" style="width: 100.0%; height: 100.0%;">Colle Umberto (IT) — pop 5,111</div>`)[0];
+                popup_caec58f603757c79583d1ef049692a3e.setContent(html_4385f5d2de507c55096fa03d5c1b5b3a);
+            
+        
+
+        circle_marker_b3804490bb9a89d97e4ebbb39cd7da92.bindPopup(popup_caec58f603757c79583d1ef049692a3e)
+        ;
+
+        
+    
+    
+            var circle_marker_6984f909e08d3d3530c677f0ecfb0058 = L.circleMarker(
+                [45.7078513, 11.5260472],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.00466614486122, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_389edf339b8859b0d8d2981f82ccd9aa = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_bb015002a6d481f49ee808c22111e155 = $(`<div id="html_bb015002a6d481f49ee808c22111e155" style="width: 100.0%; height: 100.0%;">Sarcedo (IT) — pop 5,092</div>`)[0];
+                popup_389edf339b8859b0d8d2981f82ccd9aa.setContent(html_bb015002a6d481f49ee808c22111e155);
+            
+        
+
+        circle_marker_6984f909e08d3d3530c677f0ecfb0058.bindPopup(popup_389edf339b8859b0d8d2981f82ccd9aa)
+        ;
+
+        
+    
+    
+            var circle_marker_d1fc9e091e6d651e85ac3e2659d3376e = L.circleMarker(
+                [46.18833, 12.27833],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.004440363658258, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_d4a0a4ba349c2493bd7491ec9b5408fd = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_d8890498d8f857fe13475fc450b63ff1 = $(`<div id="html_d8890498d8f857fe13475fc450b63ff1" style="width: 100.0%; height: 100.0%;">Ponte nelle Alpi-Polpet (IT) — pop 5,089</div>`)[0];
+                popup_d4a0a4ba349c2493bd7491ec9b5408fd.setContent(html_d8890498d8f857fe13475fc450b63ff1);
+            
+        
+
+        circle_marker_d1fc9e091e6d651e85ac3e2659d3376e.bindPopup(popup_d4a0a4ba349c2493bd7491ec9b5408fd)
+        ;
+
+        
+    
+    
+            var circle_marker_6b365310fb01255e6d9552172c79c6a5 = L.circleMarker(
+                [46.6498856, 11.0041954],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.004440363658258, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_8076393ecb67bebbab49601cf4803bfa = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_f977329f3241099d44ca8f5d8dce7878 = $(`<div id="html_f977329f3241099d44ca8f5d8dce7878" style="width: 100.0%; height: 100.0%;">Naturns - Naturno (IT) — pop 5,089</div>`)[0];
+                popup_8076393ecb67bebbab49601cf4803bfa.setContent(html_f977329f3241099d44ca8f5d8dce7878);
+            
+        
+
+        circle_marker_6b365310fb01255e6d9552172c79c6a5.bindPopup(popup_8076393ecb67bebbab49601cf4803bfa)
+        ;
+
+        
+    
+    
+            var circle_marker_6ea263ca3fbb30eb8a33292f7807c204 = L.circleMarker(
+                [45.8667947, 12.4339077],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.002859895237521, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_4d2e9c09bcc6f592faf84ed3ee2524e0 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_b24f676ab322cd5c90151baf66b540b1 = $(`<div id="html_b24f676ab322cd5c90151baf66b540b1" style="width: 100.0%; height: 100.0%;">Codognè (IT) — pop 5,068</div>`)[0];
+                popup_4d2e9c09bcc6f592faf84ed3ee2524e0.setContent(html_b24f676ab322cd5c90151baf66b540b1);
+            
+        
+
+        circle_marker_6ea263ca3fbb30eb8a33292f7807c204.bindPopup(popup_4d2e9c09bcc6f592faf84ed3ee2524e0)
+        ;
+
+        
+    
+    
+            var circle_marker_2eba8c74672bb574c6115857e196c6b9 = L.circleMarker(
+                [46.09313, 13.13973],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.001505208019748, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_cff69993afa9c4af4b790642ab3bcc02 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_2d11d64f973e03ae45c3183908def00e = $(`<div id="html_2d11d64f973e03ae45c3183908def00e" style="width: 100.0%; height: 100.0%;">Martignacco (IT) — pop 5,050</div>`)[0];
+                popup_cff69993afa9c4af4b790642ab3bcc02.setContent(html_2d11d64f973e03ae45c3183908def00e);
+            
+        
+
+        circle_marker_2eba8c74672bb574c6115857e196c6b9.bindPopup(popup_cff69993afa9c4af4b790642ab3bcc02)
+        ;
+
+        
+    
+    
+            var circle_marker_39d1136a752922ee9282b67e01c488b8 = L.circleMarker(
+                [46.133108, 11.2460028],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.000602083207899, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_e818afb09b0092a7a7767af55ff5a1f1 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_edbabd4148713caf83938c65c0b6b676 = $(`<div id="html_edbabd4148713caf83938c65c0b6b676" style="width: 100.0%; height: 100.0%;">Baselga di Piné (IT) — pop 5,038</div>`)[0];
+                popup_e818afb09b0092a7a7767af55ff5a1f1.setContent(html_edbabd4148713caf83938c65c0b6b676);
+            
+        
+
+        circle_marker_39d1136a752922ee9282b67e01c488b8.bindPopup(popup_e818afb09b0092a7a7767af55ff5a1f1)
+        ;
+
+        
+    
+    
+            var circle_marker_4b24dcc58b09a1e7daec2e26fde45ad6 = L.circleMarker(
+                [45.586598, 11.859005],
+                {"bubblingMouseEvents": true, "color": "purple", "dashArray": null, "dashOffset": null, "fill": true, "fillColor": "purple", "fillOpacity": 0.7, "fillRule": "evenodd", "lineCap": "round", "lineJoin": "round", "opacity": 1.0, "radius": 5.0, "stroke": true, "weight": 3}
+            ).addTo(map_e2ec93003f78b87f72b552ab4b1bae4c);
+        
+    
+        var popup_14a2ea5a719ed9e5398fa5af76826e19 = L.popup({
+  "maxWidth": "100%",
+});
+
+        
+            
+                var html_8fca820a334e2d08bf4873957dbe9209 = $(`<div id="html_8fca820a334e2d08bf4873957dbe9209" style="width: 100.0%; height: 100.0%;">Villa del Conte (IT) — pop 5,030</div>`)[0];
+                popup_14a2ea5a719ed9e5398fa5af76826e19.setContent(html_8fca820a334e2d08bf4873957dbe9209);
+            
+        
+
+        circle_marker_4b24dcc58b09a1e7daec2e26fde45ad6.bindPopup(popup_14a2ea5a719ed9e5398fa5af76826e19)
+        ;
+
+        
+    
+</script>
+</html>


### PR DESCRIPTION
## Summary
- add `write_html_map_by_country_and_population` for country-colored, population-sized markers
- generate `alps_cities_country_pop_map.html` and hook into CLI
- document new map output in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa390f52e8832d87982267d58e3b01