### PR TITLE
Add hospital presence check using OpenAI

### DIFF
--- a/city_analysis/cli.py
+++ b/city_analysis/cli.py
@@ -24,6 +24,7 @@ from .analysis import top_n_by_population, summarize
 from .country_filters import filter_excluded_countries, fill_missing_country
 from .distance import add_distance_to_perimeter_km
 from .elevation import enrich_places_with_elevation
+from .hospital import add_hospital_info
 
 
 def parse_args() -> argparse.Namespace:
@@ -113,6 +114,10 @@ def main() -> None:
         )
     else:
         print("Skipping elevation enrichment (using only OSM/GeoNames data)", file=sys.stderr)
+
+    # Check for hospitals using OpenAI web search
+    print("Checking for hospitals in each city...", file=sys.stderr)
+    enriched = add_hospital_info(enriched)
 
     # Ensure output directory
     out_dir = Path(args.out_dir)

--- a/city_analysis/hospital.py
+++ b/city_analysis/hospital.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import Dict, Iterable, List
+
+from openai import OpenAI
+
+
+def _query_hospital(client: OpenAI, city: str, country: str) -> Dict[str, str | float]:
+    prompt = (
+        "You are checking if a city has at least one hospital. "
+        "Search the web and respond in JSON with keys: has_hospital ('yes' or 'no'), "
+        "confidence (0-100 integer representing percentage), and reasoning "
+        "(concise justification including at least one reputable link). "
+        f"City: {city}, Country: {country}."
+    )
+    try:
+        response = client.responses.create(
+            model="gpt-5",
+            input=prompt,
+            web_search=True,
+        )
+        text = response.output_text
+        data = json.loads(text)
+        has_hospital = str(data.get("has_hospital", "")).lower()
+        confidence = data.get("confidence", "")
+        reasoning = data.get("reasoning", "")
+        return {
+            "has_hospital": has_hospital,
+            "hospital_confidence": confidence,
+            "hospital_reasoning": reasoning,
+        }
+    except Exception as e:  # capture API errors
+        return {
+            "has_hospital": "error",
+            "hospital_confidence": "",
+            "hospital_reasoning": str(e),
+        }
+
+
+def add_hospital_info(records: Iterable[Dict]) -> List[Dict]:
+    api_key = os.getenv("OPENAI_API_KEY")
+    try:
+        client = OpenAI(api_key=api_key)
+    except Exception as e:
+        enriched_error: List[Dict] = []
+        for record in records:
+            record.update({
+                "has_hospital": "error",
+                "hospital_confidence": "",
+                "hospital_reasoning": str(e),
+            })
+            enriched_error.append(record)
+        return enriched_error
+
+    enriched: List[Dict] = []
+    for record in records:
+        info = _query_hospital(client, record.get("name", ""), record.get("country", ""))
+        record.update(info)
+        enriched.append(record)
+    return enriched

--- a/city_analysis/io_utils.py
+++ b/city_analysis/io_utils.py
@@ -21,9 +21,10 @@ def write_csv(path: str | Path, records: Iterable[Dict]) -> None:
     
     # Use a consistent field order for better readability
     field_order = [
-        "name", "country", "latitude", "longitude", "population", 
+        "name", "country", "latitude", "longitude", "population",
         "elevation", "elevation_feet", "elevation_source", "elevation_confidence",
-        "source", "distance_km_to_alps"
+        "source", "distance_km_to_alps",
+        "has_hospital", "hospital_confidence", "hospital_reasoning"
     ]
     
     # Start with ordered fields, then add any remaining fields

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ shapely>=2.0.6
 tqdm>=4.66.4
 python-dotenv>=1.0.1
 folium>=0.15.1
+openai>=1.3.0


### PR DESCRIPTION
## Summary
- integrate OpenAI API to determine hospital presence for each city
- store hospital info, confidence, and reasoning in CSV outputs
- expose hospital check via new `add_hospital_info` module and CLI

## Testing
- `pip install -r requirements.txt`
- `python -m city_analysis.cli --help`


------
https://chatgpt.com/codex/tasks/task_e_68b471af71a0832d9516dff8f56825e8